### PR TITLE
Caching async results

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 - Fast and lightweight argument parser based on [mri](https://github.com/lukeed/mri)
 - Smart value parsing with typecast, boolean shortcuts and unknown flag handling
 - Nested sub-commands
-- Lazy and Async commands
+- Lazy and Async commands, Caching async results
 - Plugable and composable API
 - Auto generated usage and help
 

--- a/src/_utils.ts
+++ b/src/_utils.ts
@@ -25,8 +25,18 @@ export function formatLineColumns(lines: string[][], linePrefix = "") {
     .join("\n");
 }
 
-export function resolveValue<T>(input: Resolvable<T>): T | Promise<T> {
-  return typeof input === "function" ? (input as any)() : input;
+const cache = new WeakMap<Function, any>()
+
+export async function resolveValue<T>(input: Resolvable<T>): Promise<T> {
+  if (typeof input === 'function') {
+    let result: T = cache.get(input);
+    if (!result) {
+      result = await (input as any)();
+      cache.set(input, result);
+    }
+    return result;
+  }
+  return input;
 }
 
 export class CLIError extends Error {

--- a/src/usage.ts
+++ b/src/usage.ts
@@ -60,8 +60,11 @@ export async function renderUsage(cmd: CommandDef, parent?: CommandDef) {
 
   if (cmd.subCommands) {
     const commandNames: string[] = [];
-    for (const [name, sub] of Object.entries(cmd.subCommands)) {
-      commandsLines.push([name, sub.meta?.description || ""]);
+    const subCommands = await resolveValue(cmd.subCommands);
+    for (const [name, sub] of Object.entries(subCommands)) {
+      const subCmd = await resolveValue(sub);
+      const meta = await resolveValue(subCmd?.meta);
+      commandsLines.push([name, meta?.description || ""]);
       commandNames.push(name);
     }
     usageLine.push(commandNames.join("|"));


### PR DESCRIPTION
fix: async subCommands description not displayed, close #25
feat: Caching async results
