### PR TITLE
fix: support optional params in `ParsedArgs` types

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -18,19 +18,45 @@ export type ArgDef = BooleanArgDef | StringArgDef | PositionalArgDef;
 export type ArgsDef = Record<string, ArgDef>;
 export type Arg = ArgDef & { name: string; alias: string[] };
 
-export type ParsedArgs<T extends ArgsDef = ArgsDef> = { _: string[] } & Record<
-  { [K in keyof T]: T[K] extends { type: "positional" } ? K : never }[keyof T],
+export type ParsedArgs<T extends ArgsDef = ArgsDef> = { _: string[] }
+& Record<
+{ [K in keyof T]: T[K] extends { type: "positional", required: true } ? K : never }[keyof T],
+string
+>
+& Record<
+{ [K in keyof T]: T[K] extends { type: "positional", required: false } ? K : never }[keyof T],
+string | undefined
+>
+& Record<
+{ [K in keyof T]: T[K] extends { type: "positional", default: string, required: false,  } ? K : never }[keyof T],
+string
+>
+& Record<
+  { [K in keyof T]: T[K] extends { type: "positional" } ? T[K] extends { required: boolean } ? never : K : never }[keyof T],
   string
-> &
+>
+&
   Record<
     {
       [K in keyof T]: T[K] extends { type: "string" } ? K : never;
+    }[keyof T],
+    string | undefined
+  > &
+  Record<
+    {
+      [K in keyof T]: T[K] extends { type: "boolean" } ? K : never;
+    }[keyof T],
+    boolean | undefined
+  > &
+  Record<
+    {
+      [K in keyof T]: T[K] extends { type: "string", required: true } ? K : never;
     }[keyof T],
     string
   > &
   Record<
     {
-      [K in keyof T]: T[K] extends { type: "boolean" } ? K : never;
+      [K in keyof T]: T[K] extends { type: "boolean", required: true } ? K : never;
     }[keyof T],
     boolean
   > &

--- a/src/types.ts
+++ b/src/types.ts
@@ -18,20 +18,34 @@ export type ArgDef = BooleanArgDef | StringArgDef | PositionalArgDef;
 export type ArgsDef = Record<string, ArgDef>;
 export type Arg = ArgDef & { name: string; alias: string[] };
 
-export type ParsedArgs<T extends ArgsDef = ArgsDef> = { _: string[] }
-& Record<
-{ [K in keyof T]: T[K] extends { type: "positional", required: false } ? K : never }[keyof T],
-string | undefined
->
-& Record<
-{ [K in keyof T]: T[K] extends { type: "positional", default: string, required: false } | { type: "positional", required: true } ? K : never }[keyof T],
-string
->
-& Record<
-  { [K in keyof T]: T[K] extends { type: "positional" } ? T[K] extends { required: boolean } ? never : K : never }[keyof T], // No required key provided
-  string
->
-&
+export type ParsedArgs<T extends ArgsDef = ArgsDef> = { _: string[] } & Record<
+  {
+    [K in keyof T]: T[K] extends { type: "positional"; required: false }
+      ? K
+      : never;
+  }[keyof T],
+  string | undefined
+> &
+  Record<
+    {
+      [K in keyof T]: T[K] extends
+        | { type: "positional"; default: string; required: false }
+        | { type: "positional"; required: true }
+        ? K
+        : never;
+    }[keyof T],
+    string
+  > &
+  Record<
+    {
+      [K in keyof T]: T[K] extends { type: "positional" }
+        ? T[K] extends { required: boolean }
+          ? never
+          : K
+        : never;
+    }[keyof T], // No required key provided
+    string
+  > &
   Record<
     {
       [K in keyof T]: T[K] extends { type: "string" } ? K : never;
@@ -46,17 +60,24 @@ string
   > &
   Record<
     {
-      [K in keyof T]: T[K] extends { type: "string", default: string } | { type: "string", required: true } ? K : never;
+      [K in keyof T]: T[K] extends
+        | { type: "string"; default: string }
+        | { type: "string"; required: true }
+        ? K
+        : never;
     }[keyof T],
     string
   > &
   Record<
     {
-      [K in keyof T]: T[K] extends { type: "boolean", default: boolean } | { type: "boolean", required: true }  ? K : never;
+      [K in keyof T]: T[K] extends
+        | { type: "boolean"; default: boolean }
+        | { type: "boolean"; required: true }
+        ? K
+        : never;
     }[keyof T],
     boolean
   > &
-
   Record<string, string | boolean | string[]>;
 
 // ----- Command -----

--- a/src/types.ts
+++ b/src/types.ts
@@ -20,19 +20,15 @@ export type Arg = ArgDef & { name: string; alias: string[] };
 
 export type ParsedArgs<T extends ArgsDef = ArgsDef> = { _: string[] }
 & Record<
-{ [K in keyof T]: T[K] extends { type: "positional", required: true } ? K : never }[keyof T],
-string
->
-& Record<
 { [K in keyof T]: T[K] extends { type: "positional", required: false } ? K : never }[keyof T],
 string | undefined
 >
 & Record<
-{ [K in keyof T]: T[K] extends { type: "positional", default: string, required: false,  } ? K : never }[keyof T],
+{ [K in keyof T]: T[K] extends { type: "positional", default: string, required: false } | { type: "positional", required: true } ? K : never }[keyof T],
 string
 >
 & Record<
-  { [K in keyof T]: T[K] extends { type: "positional" } ? T[K] extends { required: boolean } ? never : K : never }[keyof T],
+  { [K in keyof T]: T[K] extends { type: "positional" } ? T[K] extends { required: boolean } ? never : K : never }[keyof T], // No required key provided
   string
 >
 &
@@ -50,16 +46,17 @@ string
   > &
   Record<
     {
-      [K in keyof T]: T[K] extends { type: "string", required: true } ? K : never;
+      [K in keyof T]: T[K] extends { type: "string", default: string } | { type: "string", required: true } ? K : never;
     }[keyof T],
     string
   > &
   Record<
     {
-      [K in keyof T]: T[K] extends { type: "boolean", required: true } ? K : never;
+      [K in keyof T]: T[K] extends { type: "boolean", default: boolean } | { type: "boolean", required: true }  ? K : never;
     }[keyof T],
     boolean
   > &
+
   Record<string, string | boolean | string[]>;
 
 // ----- Command -----


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme, or JSdoc annotations)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->
This PR allow the type `ParsedArgs` to support the `required` boolean property. Depending on the value of this property, the `args` coud be `type | undefined` or `type`.

- `positional`,  If required is false, the type is `type | undefined`. If required is false and a default value is provided, the type is `type`. If required is true, the type is `type`. If required does not exist, the type is `type`.
- `string`, If required is false, the type is `type | undefined`. If required is false and a default value is provided, the type is `type`. If required is true, the type is `type`. If required does not exist, the type is `undefined`.
- `boolean`, If required is false, the type is `type | undefined`. If required is false and a default value is provided, the type is `type`. If required is true, the type is `type`. If required does not exist, the type is `undefined`.

Improve DX.

_Should I add some type tests?_

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [x] I have updated the documentation accordingly.
