### PR TITLE
feat: support `enum` arg type

### DIFF
--- a/playground/hello.ts
+++ b/playground/hello.ts
@@ -17,9 +17,16 @@ const command = defineCommand({
       type: "boolean",
       description: "Use friendly greeting",
     },
+    adjective: {
+      type: "enum",
+      description: "Adjective to use in greeting",
+      options: ["awesome", "cool", "nice"],
+      default: "awesome",
+      require: false,
+    }
   },
   run({ args }) {
-    consola.log(`${args.friendly ? "Hi" : "Greetings"} ${args.name}!`);
+    consola.log(`${args.friendly ? "Hi" : "Greetings"} ${args.adjective} ${args.name}!`);
   },
 });
 

--- a/src/args.ts
+++ b/src/args.ts
@@ -22,23 +22,13 @@ export function parseArgs<T extends ArgsDef = ArgsDef>(
     if (arg.type === "positional") {
       continue;
     }
-    switch (arg.type) {
-      case "string": {
-        parseOptions.string.push(arg.name);
-
-        break;
-      }
-      case "boolean": {
-        parseOptions.boolean.push(arg.name);
-
-        break;
-      }
-      case "enum": {
-        parseOptions.enum.push(...(arg.options || []));
-
-        break;
-      }
-      // No default
+    // eslint-disable-next-line unicorn/prefer-switch
+    if (arg.type === "string") {
+      parseOptions.string.push(arg.name);
+    } else if (arg.type === "boolean") {
+      parseOptions.boolean.push(arg.name);
+    } else if (arg.type === "enum") {
+      parseOptions.enum.push(...(arg.options || []));
     }
 
     if (arg.default !== undefined) {

--- a/src/args.ts
+++ b/src/args.ts
@@ -23,22 +23,22 @@ export function parseArgs<T extends ArgsDef = ArgsDef>(
       continue;
     }
     switch (arg.type) {
-    case "string": {
-      parseOptions.string.push(arg.name);
+      case "string": {
+        parseOptions.string.push(arg.name);
 
-    break;
-    }
-    case "boolean": {
-      parseOptions.boolean.push(arg.name);
+        break;
+      }
+      case "boolean": {
+        parseOptions.boolean.push(arg.name);
 
-    break;
-    }
-    case "enum": {
-      parseOptions.enum.push(...(arg.options || []));
+        break;
+      }
+      case "enum": {
+        parseOptions.enum.push(...(arg.options || []));
 
-    break;
-    }
-    // No default
+        break;
+      }
+      // No default
     }
 
     if (arg.default !== undefined) {
@@ -81,9 +81,7 @@ export function parseArgs<T extends ArgsDef = ArgsDef>(
           "EARG",
         );
       }
-    }
-
-     else if (arg.required && parsedArgsProxy[arg.name] === undefined) {
+    } else if (arg.required && parsedArgsProxy[arg.name] === undefined) {
       throw new CLIError(`Missing required argument: --${arg.name}`, "EARG");
     }
   }

--- a/src/args.ts
+++ b/src/args.ts
@@ -64,10 +64,13 @@ export function parseArgs<T extends ArgsDef = ArgsDef>(
     } else if (arg.type === "enum") {
       const argument = parsedArgsProxy[arg.name];
       const options = arg.options || [];
-
-      if (argument !== undefined && !options.includes(argument)) {
+      if (
+        argument !== undefined &&
+        options.length > 0 &&
+        !options.includes(argument)
+      ) {
         throw new CLIError(
-          `Invalid value for argument: --${arg.name}=${argument}`,
+          `Invalid value for argument: \`--${arg.name}\` (\`${argument}\`). Expected one of: ${options.map((o) => `\`${o}\``).join(", ")}.`,
           "EARG",
         );
       }

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,6 +1,6 @@
 // ----- Args -----
 
-export type ArgType = "boolean" | "string" | "positional" | undefined;
+export type ArgType = "boolean" | "string" | "positional" | 'enum' | undefined;
 
 export type _ArgDef<T extends ArgType, VT extends boolean | string> = {
   type?: T;
@@ -9,12 +9,14 @@ export type _ArgDef<T extends ArgType, VT extends boolean | string> = {
   alias?: string | string[];
   default?: VT;
   required?: boolean;
+  options?: (string | number)[];
 };
 
-export type BooleanArgDef = _ArgDef<"boolean", boolean>;
-export type StringArgDef = _ArgDef<"string", string>;
-export type PositionalArgDef = Omit<_ArgDef<"positional", string>, "alias">;
-export type ArgDef = BooleanArgDef | StringArgDef | PositionalArgDef;
+export type BooleanArgDef = Omit<_ArgDef<"boolean", boolean>, "options">;
+export type StringArgDef = Omit<_ArgDef<"string", string>, "options">;
+export type PositionalArgDef = Omit<_ArgDef<"positional", string>, "alias"| "options">;
+export type EnumArgDef = _ArgDef<'enum', string>;
+export type ArgDef = BooleanArgDef | StringArgDef | PositionalArgDef | EnumArgDef;
 export type ArgsDef = Record<string, ArgDef>;
 export type Arg = ArgDef & { name: string; alias: string[] };
 
@@ -33,6 +35,13 @@ export type ParsedArgs<T extends ArgsDef = ArgsDef> = { _: string[] } & Record<
       [K in keyof T]: T[K] extends { type: "boolean" } ? K : never;
     }[keyof T],
     boolean
+  > & Record<
+    {
+      [K in keyof T]: T[K] extends { type: "enum" } ? K : never;
+    }[keyof T],
+    {
+      [K in keyof T]: T[K] extends { options: (infer U) } ? U : never
+    }[keyof T]
   > &
   Record<string, string | boolean | string[]>;
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,6 +1,6 @@
 // ----- Args -----
 
-export type ArgType = "boolean" | "string" | "positional" | 'enum' | undefined;
+export type ArgType = "boolean" | "string" | "positional" | "enum" | undefined;
 
 export type _ArgDef<T extends ArgType, VT extends boolean | string> = {
   type?: T;
@@ -14,9 +14,16 @@ export type _ArgDef<T extends ArgType, VT extends boolean | string> = {
 
 export type BooleanArgDef = Omit<_ArgDef<"boolean", boolean>, "options">;
 export type StringArgDef = Omit<_ArgDef<"string", string>, "options">;
-export type PositionalArgDef = Omit<_ArgDef<"positional", string>, "alias"| "options">;
-export type EnumArgDef = _ArgDef<'enum', string>;
-export type ArgDef = BooleanArgDef | StringArgDef | PositionalArgDef | EnumArgDef;
+export type PositionalArgDef = Omit<
+  _ArgDef<"positional", string>,
+  "alias" | "options"
+>;
+export type EnumArgDef = _ArgDef<"enum", string>;
+export type ArgDef =
+  | BooleanArgDef
+  | StringArgDef
+  | PositionalArgDef
+  | EnumArgDef;
 export type ArgsDef = Record<string, ArgDef>;
 export type Arg = ArgDef & { name: string; alias: string[] };
 
@@ -35,12 +42,13 @@ export type ParsedArgs<T extends ArgsDef = ArgsDef> = { _: string[] } & Record<
       [K in keyof T]: T[K] extends { type: "boolean" } ? K : never;
     }[keyof T],
     boolean
-  > & Record<
+  > &
+  Record<
     {
       [K in keyof T]: T[K] extends { type: "enum" } ? K : never;
     }[keyof T],
     {
-      [K in keyof T]: T[K] extends { options: (infer U) } ? U : never
+      [K in keyof T]: T[K] extends { options: infer U } ? U : never;
     }[keyof T]
   > &
   Record<string, string | boolean | string[]>;

--- a/src/usage.ts
+++ b/src/usage.ts
@@ -55,6 +55,9 @@ export async function renderUsage<T extends ArgsDef = ArgsDef>(
           ? `=${
               arg.valueHint ? `<${arg.valueHint}>` : `"${arg.default || ""}"`
             }`
+          : "") +
+        (arg.type === "enum" && arg.options
+          ? `=<${arg.options.join("|")}>`
           : "");
       argLines.push([
         "`" + argStr + (isRequired ? " (required)" : "") + "`",


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->
fix #82

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme, or JSdoc annotations)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [x] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->
I add support for `enum`. This allow to specify a list of possible values for a property and fail if the value is not in the list.

- [ ] I have a type issue with ParsedArgs. I would love to infer from the options. eg: if ['a', 'b'] are the options, then the type of the property should be 'a' | 'b' instead of string or number. I don't know how to solve it.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
