### PR TITLE
feat: support before/after hooks

### DIFF
--- a/src/_utils.ts
+++ b/src/_utils.ts
@@ -1,5 +1,13 @@
 import type { Resolvable } from "./types";
 
+export  function runIfFunction<T extends (...args: any[]) => Promise<void> | void>(val: T | undefined) {
+  return async function (...args: Parameters<T>) {
+    if (typeof val === 'function') {
+      await val(...args)
+    }
+  }
+}
+
 export function toArray(val: any) {
   if (Array.isArray(val)) {
     return val;

--- a/src/command.ts
+++ b/src/command.ts
@@ -1,5 +1,5 @@
 import type { CommandContext, CommandDef, ArgsDef } from "./types";
-import { CLIError, resolveValue } from "./_utils";
+import { CLIError, resolveValue, runIfFunction } from "./_utils";
 import { parseArgs } from "./args";
 
 export function defineCommand<T extends ArgsDef = ArgsDef>(
@@ -29,9 +29,7 @@ export async function runCommand<T extends ArgsDef = ArgsDef>(
   };
 
   // Setup hook
-  if (typeof cmd.setup === "function") {
-    await cmd.setup(context);
-  }
+  await runIfFunction(cmd.setup)(context);
 
   // Handle sub command
   try {
@@ -60,13 +58,11 @@ export async function runCommand<T extends ArgsDef = ArgsDef>(
     }
 
     // Handle main command
-    if (typeof cmd.run === "function") {
-      await cmd.run(context);
-    }
+    await runIfFunction(cmd.before)(context);
+    await runIfFunction(cmd.run)(context);
   } finally {
-    if (typeof cmd.cleanup === "function") {
-      await cmd.cleanup(context);
-    }
+    await runIfFunction(cmd.after)(context);
+    await runIfFunction(cmd.cleanup)(context);
   }
 }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -54,6 +54,8 @@ export type CommandDef<T extends ArgsDef = ArgsDef> = {
   meta?: Resolvable<CommandMeta>;
   args?: Resolvable<T>;
   subCommands?: Resolvable<SubCommandsDef>;
+  before?: (context: CommandContext<T>) => any | Promise<any>;
+  after?: (context: CommandContext<T>) => any | Promise<any>;
   setup?: (context: CommandContext<T>) => any | Promise<any>;
   cleanup?: (context: CommandContext<T>) => any | Promise<any>;
   run?: (context: CommandContext<T>) => any | Promise<any>;


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org) 
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

Support hooks befor/after execute run func https://github.com/unjs/citty/issues/98

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme, or JSdoc annotations)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [x] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

Add optional `before` `after` in `CommandDef` type run these callback functions before or after `runCommand`.

Resolves https://github.com/unjs/citty/issues/98

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
