### PR TITLE
feat: add .catch to command declaration

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "dev": "vitest dev",
     "lint": "eslint --cache --ext .ts,.js,.mjs,.cjs . && prettier -c src test",
     "lint:fix": "eslint --cache --ext .ts,.js,.mjs,.cjs . --fix && prettier -c src test -w",
+    "format": "prettier -c src test -w",
     "prepack": "pnpm run build",
     "play": "jiti ./playground/cli.ts",
     "release": "pnpm test && changelogen --release --push && npm publish",

--- a/playground/cli.ts
+++ b/playground/cli.ts
@@ -18,4 +18,6 @@ const main = defineCommand({
   },
 });
 
-runMain(main);
+if (process.env.NODE_ENV !== "test") {
+  runMain(main);
+}

--- a/playground/cli.ts
+++ b/playground/cli.ts
@@ -1,6 +1,6 @@
 import { defineCommand, runMain } from "../src";
 
-const main = defineCommand({
+export const main = defineCommand({
   meta: {
     name: "citty",
     version: "1.0.0",
@@ -15,6 +15,9 @@ const main = defineCommand({
   subCommands: {
     build: () => import("./commands/build").then((r) => r.default),
     deploy: () => import("./commands/deploy").then((r) => r.default),
+    error: () => import("./commands/error").then((r) => r.default),
+    "error-no-catch": () =>
+      import("./commands/error-no-catch").then((r) => r.default),
   },
 });
 

--- a/playground/commands/error-no-catch.ts
+++ b/playground/commands/error-no-catch.ts
@@ -1,0 +1,36 @@
+import { defineCommand } from "../../src";
+
+export default defineCommand({
+  meta: {
+    name: "error-no-catch",
+    description:
+      "Throws an error to test .catch functionality, does not have error handling",
+  },
+
+  args: {
+    throwType: {
+      type: "string",
+    },
+  },
+
+  run({ args }) {
+    switch (args.throwType) {
+      case "string": {
+        console.log("Throw string");
+        // we intentionally are throwing something invalid for testing purposes
+        // eslint-disable-next-line no-throw-literal
+        throw "Not an error!";
+      }
+      case "empty": {
+        console.log("Throw undefined");
+        // we intentionally are throwing something invalid for testing purposes
+        // eslint-disable-next-line no-throw-literal
+        throw undefined;
+      }
+      default: {
+        console.log("Throw Error");
+        throw new Error("Error!");
+      }
+    }
+  },
+});

--- a/playground/commands/error.ts
+++ b/playground/commands/error.ts
@@ -1,0 +1,19 @@
+import consola from "consola";
+import { defineCommand } from "../../src";
+
+export default defineCommand({
+  meta: {
+    name: "error",
+    description: "Throws an error to test .catch functionality",
+  },
+
+  run() {
+    throw new Error("Hello World");
+  },
+  catch(_, e) {
+    consola.error(`Caught error: ${e}`);
+    if (!(e instanceof Error)) {
+      throw new TypeError("Recieved non-error value");
+    }
+  },
+});

--- a/src/command.ts
+++ b/src/command.ts
@@ -64,6 +64,17 @@ export async function runCommand<T extends ArgsDef = ArgsDef>(
     if (typeof cmd.run === "function") {
       result = await cmd.run(context);
     }
+  } catch (error_) {
+    const error =
+      error_ instanceof Error
+        ? error_
+        : new Error(error_?.toString() ?? "Unknown Error", { cause: error_ });
+    if (typeof cmd.catch === "function") {
+      // Attempt to coerce e into an error to ensure type safety
+      await cmd.catch(context, error);
+    } else {
+      throw error;
+    }
   } finally {
     if (typeof cmd.cleanup === "function") {
       await cmd.cleanup(context);

--- a/src/main.ts
+++ b/src/main.ts
@@ -38,7 +38,9 @@ export async function runMain<T extends ArgsDef = ArgsDef>(
       await showUsage(...(await resolveSubCommand(cmd, rawArgs)));
     }
     consola.error(error.message);
-    process.exit(1);
+    if (process.env.NODE_ENV !== "test") {
+      process.exit(1);
+    }
   }
 }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -56,6 +56,7 @@ export type CommandDef<T extends ArgsDef = ArgsDef> = {
   subCommands?: Resolvable<SubCommandsDef>;
   setup?: (context: CommandContext<T>) => any | Promise<any>;
   cleanup?: (context: CommandContext<T>) => any | Promise<any>;
+  catch?: (context: CommandContext<T>, e: Error) => any | Promise<any>;
   run?: (context: CommandContext<T>) => any | Promise<any>;
 };
 

--- a/test/error.test.ts
+++ b/test/error.test.ts
@@ -1,0 +1,36 @@
+import { expect, it, describe } from "vitest";
+import { main } from "../playground/cli";
+import { runCommand } from "../src/command";
+
+describe("citty", () => {
+  it.todo("pass", () => {
+    expect(true).toBe(true);
+  });
+
+  describe("commands", () => {
+    describe("error", () => {
+      it("should catch thrown errors when present", () => {
+        expect(() =>
+          runCommand(main, { rawArgs: ["error"] }),
+        ).not.toThrowError();
+      });
+      it("should still recieve an error when a string is thrown from the command", () =>
+        expect(
+          runCommand(main, {
+            rawArgs: ["error-no-catch", "--throwType", "string"],
+          }),
+        ).rejects.toThrowError());
+      it("should still recieve an error when undefined is thrown from the command", () =>
+        expect(
+          runCommand(main, {
+            rawArgs: ["error-no-catch", "--throwType", "empty"],
+          }),
+        ).rejects.toThrowError());
+
+      it("should not interfere with default error handling when not present", () =>
+        expect(() =>
+          runCommand(main, { rawArgs: ["error-no-catch"] }),
+        ).rejects.toBeInstanceOf(Error));
+    });
+  });
+});


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org) 
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

Resolves unjs/citty#112

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme, or JSdoc annotations)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [x] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail -->
This adds an additional function `.catch` to a command definition. It works similarly to setup and cleanup, but the error does not bubble all the way up if caught.

This allows for custom error handling that may differ from the default (e.g. changing the console output of a CLI when an uncaught exception occurs anywhere in the app).

Example usage of catch:

```javascript
const main = defineCommand({
	meta: {
		name: 'my-cli',
		description: 'my cli command'
	},
	/**
	 * @param {import("citty").CommandContext} ctx 
	 * @param {Error} e 
	 */
	catch(ctx, e) {
		console.log("Error occured!", e.message) // -> Error occured! meep
		process.exit(1);
	},

	run() {
		throw new Error("meep")
	}
});

runMain(main);

```

<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- ~~[ ] I have updated the documentation accordingly.~~ There doesn't seem to be a place in the documentation to update, but I did write tests with full coverage
