### PR TITLE
Feat: Class based usage rendering

### DIFF
--- a/src/usage.ts
+++ b/src/usage.ts
@@ -1,7 +1,7 @@
 import consola from "consola";
 import { colors } from "consola/utils";
 import { formatLineColumns, resolveValue } from "./_utils";
-import type { ArgsDef, CommandDef } from "./types";
+import type { Arg, ArgsDef, CommandDef } from "./types";
 import { resolveArgs } from "./args";
 
 export async function showUsage<T extends ArgsDef = ArgsDef>(
@@ -9,116 +9,333 @@ export async function showUsage<T extends ArgsDef = ArgsDef>(
   parent?: CommandDef<T>,
 ) {
   try {
-    consola.log((await renderUsage(cmd, parent)) + "\n");
+    const renderer = await new RenderUsage(cmd, parent);
+    consola.log((await renderer.toString()) + "\n");
   } catch (error) {
     consola.error(error);
   }
 }
 
-export async function renderUsage<T extends ArgsDef = ArgsDef>(
+/**
+ * @deprecated Use `new RenderUsage(cmd, parent).toString()` instead.
+ */
+export function renderUsage<T extends ArgsDef = ArgsDef>(
   cmd: CommandDef<T>,
   parent?: CommandDef<T>,
 ) {
-  const cmdMeta = await resolveValue(cmd.meta || {});
-  const cmdArgs = resolveArgs(await resolveValue(cmd.args || {}));
-  const parentMeta = await resolveValue(parent?.meta || {});
+  const renderer = new RenderUsage(cmd, parent);
+  return renderer.toString();
+}
 
-  const commandName =
-    `${parentMeta.name ? `${parentMeta.name} ` : ""}` +
-    (cmdMeta.name || process.argv[1]);
+export abstract class AbstractCommandArgumentDef<T extends Arg = Arg> {
+  public readonly arg: T;
 
-  const argLines: string[][] = [];
-  const posLines: string[][] = [];
-  const commandsLines: string[][] = [];
-  const usageLine = [];
+  constructor(arg: T) {
+    this.arg = arg;
+  }
 
-  for (const arg of cmdArgs) {
-    if (arg.type === "positional") {
-      const name = arg.name.toUpperCase();
-      const isRequired = arg.required !== false && arg.default === undefined;
-      // (isRequired ? " (required)" : " (optional)"
-      const usageHint = arg.default ? `="${arg.default}"` : "";
-      posLines.push(["`" + name + usageHint + "`", arg.description || ""]);
-      usageLine.push(isRequired ? `<${name}>` : `[${name}]`);
-    } else {
-      const isRequired = arg.required === true && arg.default === undefined;
-      const argStr =
-        (arg.type === "boolean" && arg.default === true
-          ? [
-              ...(arg.alias || []).map((a) => `--no-${a}`),
-              `--no-${arg.name}`,
-            ].join(", ")
-          : [...(arg.alias || []).map((a) => `-${a}`), `--${arg.name}`].join(
-              ", ",
-            )) +
-        (arg.type === "string" && (arg.valueHint || arg.default)
-          ? `=${
-              arg.valueHint ? `<${arg.valueHint}>` : `"${arg.default || ""}"`
-            }`
-          : "");
-      argLines.push([
-        "`" + argStr + (isRequired ? " (required)" : "") + "`",
-        arg.description || "",
-      ]);
-      if (isRequired) {
-        usageLine.push(argStr);
+  public get name() {
+    return this.arg.name;
+  }
+
+  public get description() {
+    return this.arg.description || "";
+  }
+
+  public get type() {
+    return this.arg.type || "string";
+  }
+
+  public get valueHint() {
+    return this.arg.valueHint || "";
+  }
+
+  public get alias() {
+    return this.arg.alias || [];
+  }
+
+  public get default() {
+    return this.arg.default;
+  }
+
+  public get required() {
+    return this.arg.required === true && this.arg.default === undefined;
+  }
+}
+
+export class CommandOptionsDef<
+  T extends Arg = Arg,
+> extends AbstractCommandArgumentDef<T> {
+  public get names(): string[] {
+    const names = [...this.alias, this.name];
+    const prefix =
+      this.type === "boolean" && this.default === true ? "no-" : "";
+
+    return names.map(
+      (name) => `${name.length > 1 ? "-" : ""}-${prefix}${name}`,
+    );
+  }
+}
+
+export class CommandArgumentsDef<
+  T extends Arg = Arg,
+> extends AbstractCommandArgumentDef<T> {}
+
+export abstract class AbstractCommandDef<T extends ArgsDef = ArgsDef> {
+  protected readonly cmd: CommandDef<T>;
+  protected readonly parent?: CommandDef<T>;
+
+  constructor(cmd: CommandDef<T>, parent?: CommandDef<T>) {
+    this.cmd = cmd;
+    this.parent = parent;
+  }
+
+  public cmdMeta() {
+    return resolveValue(this.cmd.meta || {});
+  }
+
+  public async cmdArgs() {
+    return resolveArgs(await resolveValue(this.cmd.args || {}));
+  }
+
+  public parentMeta() {
+    return resolveValue(this.parent?.meta || {});
+  }
+
+  public async version() {
+    const cmdMeta = await this.cmdMeta();
+    const parentMeta = await this.parentMeta();
+
+    return cmdMeta.version || parentMeta.version;
+  }
+
+  public async subcommands() {
+    const commands: RenderCommandDef<T>[] = [];
+
+    if (this.cmd.subCommands) {
+      const subCommands = await resolveValue(this.cmd.subCommands);
+
+      for (const [name, sub] of Object.entries(subCommands)) {
+        const subCmd = await resolveValue(sub);
+        commands.push(new RenderCommandDef(subCmd, this.cmd, name));
       }
     }
+
+    return commands;
+  }
+}
+
+export class RenderCommandDef<
+  T extends ArgsDef = ArgsDef,
+> extends AbstractCommandDef<T> {
+  constructor(
+    cmd: CommandDef<T>,
+    parent?: CommandDef<T>,
+    protected readonly _name?: string,
+  ) {
+    super(cmd, parent);
   }
 
-  if (cmd.subCommands) {
-    const commandNames: string[] = [];
-    const subCommands = await resolveValue(cmd.subCommands);
-    for (const [name, sub] of Object.entries(subCommands)) {
-      const subCmd = await resolveValue(sub);
-      const meta = await resolveValue(subCmd?.meta);
-      commandsLines.push([`\`${name}\``, meta?.description || ""]);
-      commandNames.push(name);
+  public async commandName() {
+    const parentMeta = await this.parentMeta();
+    const name = await this.name();
+
+    return `${parentMeta.name ? `${parentMeta.name} ` : ""}` + name;
+  }
+
+  public async name() {
+    if (this._name) {
+      return this._name;
     }
-    usageLine.push(commandNames.join("|"));
+
+    const cmdMeta = await this.cmdMeta();
+
+    return cmdMeta.name || process.argv[1];
   }
 
-  const usageLines: (string | undefined)[] = [];
+  public async description() {
+    const cmdMeta = await this.cmdMeta();
 
-  const version = cmdMeta.version || parentMeta.version;
-
-  usageLines.push(
-    colors.gray(
-      `${cmdMeta.description} (${
-        commandName + (version ? ` v${version}` : "")
-      })`,
-    ),
-    "",
-  );
-
-  const hasOptions = argLines.length > 0 || posLines.length > 0;
-  usageLines.push(
-    `${colors.underline(colors.bold("USAGE"))} \`${commandName}${
-      hasOptions ? " [OPTIONS]" : ""
-    } ${usageLine.join(" ")}\``,
-    "",
-  );
-
-  if (posLines.length > 0) {
-    usageLines.push(colors.underline(colors.bold("ARGUMENTS")), "");
-    usageLines.push(formatLineColumns(posLines, "  "));
-    usageLines.push("");
+    return cmdMeta.description || "";
   }
 
-  if (argLines.length > 0) {
-    usageLines.push(colors.underline(colors.bold("OPTIONS")), "");
-    usageLines.push(formatLineColumns(argLines, "  "));
-    usageLines.push("");
+  public async arguments() {
+    const cmdArgs = await this.cmdArgs();
+
+    return cmdArgs
+      .filter((arg) => arg.type === "positional")
+      .map((arg) => new CommandArgumentsDef(arg));
   }
 
-  if (commandsLines.length > 0) {
-    usageLines.push(colors.underline(colors.bold("COMMANDS")), "");
-    usageLines.push(formatLineColumns(commandsLines, "  "));
-    usageLines.push(
-      "",
-      `Use \`${commandName} <command> --help\` for more information about a command.`,
+  public async properties() {
+    const cmdArgs = await this.cmdArgs();
+
+    return cmdArgs
+      .filter((arg) => arg.type !== "positional")
+      .map((arg) => new CommandOptionsDef(arg));
+  }
+}
+
+export class RenderUsage<T extends ArgsDef = ArgsDef> implements IRendersUsage {
+  public readonly command: RenderCommandDef<T>;
+
+  constructor(cmd: CommandDef<T>, parent?: CommandDef<T>, _name?: string) {
+    this.command = new RenderCommandDef<T>(cmd, parent, _name);
+  }
+
+  public async description(): Promise<string> {
+    const [cmdMeta, commandName, version] = await Promise.all([
+      this.command.cmdMeta(),
+      this.command.commandName(),
+      this.command.version(),
+    ]);
+
+    return colors.gray(
+      `${cmdMeta.description} (${commandName + (version ? ` v${version}` : "")})`,
     );
   }
 
-  return usageLines.filter((l) => typeof l === "string").join("\n");
+  public async usage(): Promise<string> {
+    const [commandName, args, properties, subcommands] = await Promise.all([
+      this.command.commandName(),
+      this.command.arguments(),
+      this.command.properties(),
+      this.command.subcommands(),
+    ]);
+
+    const hasOptions = args.length > 0 || properties.length > 0;
+
+    const [_arguments, _options, _commands] = await Promise.all([
+      args.length > 0
+        ? `${Promise.all(args.map((arg) => (arg.required === true && arg.default === undefined ? `<${arg.name.toUpperCase()}>` : undefined))).then((list) => list.filter(Boolean).join(" "))}`
+        : "",
+      properties.length > 0
+        ? `${await Promise.all(
+            properties
+              .filter((property) => property.required)
+              .map((property) => property.names.join(", ")),
+          )}`
+        : "",
+      `${await Promise.all(subcommands.map((cmd) => cmd.name())).then((list) => list.join("|"))}`,
+    ]);
+
+    return [
+      `${colors.underline(colors.bold("USAGE"))}`,
+      `\``,
+      `${commandName}${hasOptions ? " [OPTIONS]" : ""}`,
+      _arguments,
+      _options,
+      _commands,
+      `\``,
+    ].join(" ");
+  }
+
+  public async agruments(): Promise<string> {
+    const args = await this.command.arguments();
+    const lines: string[] = [];
+
+    if (args.length === 0) {
+      return "";
+    }
+
+    lines.push(colors.underline(colors.bold("ARGUMENTS")), "");
+
+    const columns = await Promise.all(
+      args.map((arg) => {
+        const name = arg.name.toUpperCase();
+        const usageHint = arg.default ? `="${arg.default}"` : "";
+        return [`\`${name + usageHint}\``, arg.description || ""];
+      }),
+    );
+
+    lines.push(formatLineColumns(columns, "  "));
+
+    return lines.join("\n");
+  }
+
+  public async options(): Promise<string> {
+    const properties = await this.command.properties();
+
+    if (properties.length === 0) {
+      return "";
+    }
+
+    const lines: string[] = [];
+
+    lines.push(colors.underline(colors.bold("OPTIONS")), "");
+
+    const columns = properties.map((arg) => {
+      return [
+        `\`${arg.names.join(", ")}${arg.required ? " (required)" : ""}\``,
+        arg.description || "",
+      ];
+    });
+
+    lines.push(formatLineColumns(columns, "  "));
+    lines.push("");
+
+    return lines.join("\n");
+  }
+
+  public async commands(): Promise<string> {
+    const lines: string[] = [];
+    const subcommands = await this.command.subcommands();
+
+    if (subcommands.length === 0) {
+      return "";
+    }
+
+    const commandName = await this.command.commandName();
+
+    lines.push(colors.underline(colors.bold("COMMANDS")), "");
+
+    const columns = await Promise.all(
+      subcommands.map(async (cmd) => {
+        const name = await cmd.name();
+        const description = await cmd.description();
+        return [`\`${name}\``, description];
+      }),
+    );
+
+    lines.push(formatLineColumns(columns, "  "));
+    lines.push(
+      "",
+      `Use \`${commandName} <command> --help\` for more information about a command.`,
+    );
+
+    return lines.join("\n");
+  }
+
+  public async toString() {
+    const [description, usage, args, options, commands] = await Promise.all([
+      this.description(),
+      this.usage(),
+      this.agruments(),
+      this.options(),
+      this.commands(),
+    ]);
+
+    const lines: string[] = [];
+
+    lines.push(description, "");
+    lines.push(usage, "");
+
+    if (args) {
+      lines.push(args, "");
+    }
+
+    if (options) {
+      lines.push(options, "");
+    }
+
+    if (commands) {
+      lines.push(commands, "");
+    }
+
+    return lines.join("\n");
+  }
+}
+
+export interface IRendersUsage {
+  toString(): Promise<string>;
 }


### PR DESCRIPTION
### 🔗 [#117](https://github.com/unjs/citty/issues/117)

### ✨ Feature

- [ ] 📖 Documentation (updates to the documentation, readme, or JSdoc annotations)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [x] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

This PR is somewhat a protoype in relation to feature request #117 concerning the ability to easily extending the generation of usage output.

The current implementation is a single function that returns a string. If a user want to alter the output they have to implement the `renderUsage` function and make alternations. This is fragile to new updates in core implementation and makes the developer reImplement a lot of the utils functions like `resolveValue`, `resolveArgs` and `formatLineColumns`.

This PR allows to simply extend the `RenderUsage` class and override the methods they want to alter. Alternatively the can create their own class with a custom "template".

Again, it's a foundation to from where we can discuss direction and relevance 🙂

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
