### PR TITLE
refactor(types)!: improve type safety and inference of args

### DIFF
--- a/src/command.ts
+++ b/src/command.ts
@@ -2,7 +2,7 @@ import type { CommandContext, CommandDef, ArgsDef } from "./types";
 import { CLIError, resolveValue } from "./_utils";
 import { parseArgs } from "./args";
 
-export function defineCommand<T extends ArgsDef = ArgsDef>(
+export function defineCommand<const T extends ArgsDef = ArgsDef>(
   def: CommandDef<T>,
 ): CommandDef<T> {
   return def;

--- a/src/usage.ts
+++ b/src/usage.ts
@@ -35,17 +35,15 @@ export async function renderUsage<T extends ArgsDef = ArgsDef>(
   for (const arg of cmdArgs) {
     if (arg.type === "positional") {
       const name = arg.name.toUpperCase();
-      const isRequired = arg.required !== false && arg.default === undefined;
-      // (isRequired ? " (required)" : " (optional)"
       const defaultHint = arg.default ? `="${arg.default}"` : "";
+
       posLines.push([
         "`" + name + defaultHint + "`",
         arg.description || "",
         arg.valueHint ? `<${arg.valueHint}>` : "",
       ]);
-      usageLine.push(isRequired ? `<${name}>` : `[${name}]`);
+      usageLine.push(arg.required ? `<${name}>` : `[${name}]`);
     } else {
-      const isRequired = arg.required === true && arg.default === undefined;
       const argStr =
         (arg.type === "boolean" && arg.default === true
           ? [
@@ -67,11 +65,13 @@ export async function renderUsage<T extends ArgsDef = ArgsDef>(
       const description = isNegative
         ? arg.negativeDescription || arg.description
         : arg.description;
+
       argLines.push([
-        "`" + argStr + (isRequired ? " (required)" : "") + "`",
+        "`" + argStr + (arg.required ? " (required)" : "") + "`",
         description || "",
       ]);
-      if (isRequired) {
+
+      if (arg.required) {
         usageLine.push(argStr);
       }
     }
@@ -106,6 +106,7 @@ export async function renderUsage<T extends ArgsDef = ArgsDef>(
   );
 
   const hasOptions = argLines.length > 0 || posLines.length > 0;
+
   usageLines.push(
     `${colors.underline(colors.bold("USAGE"))} \`${commandName}${
       hasOptions ? " [OPTIONS]" : ""


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org) 
-->

### 🔗 Linked issue

https://github.com/nuxt/cli/pull/381 inspired me to work on this PR, as I noticed the args can be `undefined` even though their types do not reflect this.

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme, or JSdoc annotations)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [x] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

It turned out to be one of my deeper dives into the world of TypeScript ✨ 

This PR:
- defines the exact set of available properties based on the arg type
- defines a relationship between `required` and `default` properties
- adjust the types of `ctx.args.<arg>` based on `default` and `required` property (currently, `ctx.args.<arg>` is never `undefined`)
- inferres the exact possible values for an enum arg when accessing via `ctx.args.<arg>` (e.g. `1 | 2 | 3` rather than `number`)

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
