### PR TITLE
feat: exports low level APIs

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,21 @@ Runs a command with usage support and graceful error handling.
 
 Create a wrapper around command that calls `runMain` when called.
 
+### `runRawMain`
+
+Runs a command. Unlike `runMain`, this function requires you to define command execution handling like `handleCommand` and error handling yourself like `handleError` and specify them as arguments.
+
+> [!NOTE]
+> This function is a low-level function compared to `runMain`. You should also implement your own `showUsage` etc. and specify it as an option.
+
+### `handleCommand`
+
+A handler that implements the logic to execute commands with usage support. It is used inside in `runMain`. You can specify it as a helper to `run`.
+
+### `handleError`
+
+An error handler that implementes the logic to graceful error handling. It is used inside `runMain`. You can specify it as a helper to `run`.
+
 ### `runCommand`
 
 Parses input args and runs command and sub-commands (unsupervised). You can access `result` key from returnd/awaited value to access command's result.
@@ -103,6 +118,10 @@ Renders command usage to a string value.
 ### `showUsage`
 
 Renders usage and prints to the console
+
+### `formatLineColumns`
+
+Formats line columns. If you define custom `showUsage`, it is convenient to adjust the format with this function.
 
 ## Development
 

--- a/src/_utils.ts
+++ b/src/_utils.ts
@@ -7,25 +7,6 @@ export function toArray(val: any) {
   return val === undefined ? [] : [val];
 }
 
-export function formatLineColumns(lines: string[][], linePrefix = "") {
-  const maxLengh: number[] = [];
-  for (const line of lines) {
-    for (const [i, element] of line.entries()) {
-      maxLengh[i] = Math.max(maxLengh[i] || 0, element.length);
-    }
-  }
-  return lines
-    .map((l) =>
-      l
-        .map(
-          (c, i) =>
-            linePrefix + c[i === 0 ? "padStart" : "padEnd"](maxLengh[i]),
-        )
-        .join("  "),
-    )
-    .join("\n");
-}
-
 export function resolveValue<T>(input: Resolvable<T>): T | Promise<T> {
   return typeof input === "function" ? (input as any)() : input;
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,8 +1,14 @@
 export * from "./types";
 export type { RunCommandOptions } from "./command";
-export type { RunMainOptions } from "./main";
+export type { RunMainOptions, RunArgs, RunHandlers } from "./main";
 
 export { defineCommand, runCommand } from "./command";
 export { parseArgs } from "./args";
-export { renderUsage, showUsage } from "./usage";
-export { runMain, createMain } from "./main";
+export { renderUsage, showUsage, formatLineColumns } from "./usage";
+export {
+  runMain,
+  createMain,
+  runRawMain,
+  handleCommand,
+  handleError,
+} from "./main";

--- a/src/main.ts
+++ b/src/main.ts
@@ -9,37 +9,75 @@ export interface RunMainOptions {
   showUsage?: typeof _showUsage;
 }
 
+export interface RunArgs<T extends ArgsDef = ArgsDef> {
+  cmd: CommandDef<T>;
+  rawArgs: string[];
+  showUsage?: typeof _showUsage;
+}
+
+export interface RunHandlers<
+  T extends ArgsDef = ArgsDef,
+  E extends Error = Error,
+> {
+  command: (args: RunArgs<T>) => Promise<void>;
+  error: (args: RunArgs<T>, error: E) => Promise<void>;
+}
+
+export async function handleCommand<T extends ArgsDef = ArgsDef>({
+  cmd,
+  rawArgs,
+  showUsage,
+}: RunArgs<T>): Promise<void> {
+  if ((rawArgs.includes("--help") || rawArgs.includes("-h")) && showUsage) {
+    await showUsage(...(await resolveSubCommand(cmd, rawArgs)));
+    process.exit(0);
+  } else if (rawArgs.length === 1 && rawArgs[0] === "--version") {
+    const meta =
+      typeof cmd.meta === "function" ? await cmd.meta() : await cmd.meta;
+    if (!meta?.version) {
+      throw new CLIError("No version specified", "E_NO_VERSION");
+    }
+    consola.log(meta.version);
+  } else {
+    await runCommand(cmd, { rawArgs });
+  }
+}
+
+export async function handleError<
+  T extends ArgsDef = ArgsDef,
+  E extends Error = Error,
+>({ cmd, rawArgs, showUsage }: RunArgs<T>, error: E) {
+  const isCLIError = error instanceof CLIError;
+  if (!isCLIError) {
+    consola.error(error, "\n");
+  }
+  if (isCLIError && showUsage) {
+    await showUsage(...(await resolveSubCommand(cmd, rawArgs)));
+  }
+  consola.error(error.message);
+  process.exit(1);
+}
+
+export async function runRawMain<T extends ArgsDef = ArgsDef>(
+  cmd: CommandDef<T>,
+  handlers: RunHandlers<T>,
+  opts: RunMainOptions = {},
+) {
+  const rawArgs = opts.rawArgs || process.argv.slice(2);
+  const args = { cmd, rawArgs, showUsage: opts.showUsage };
+  try {
+    await handlers.command(args);
+  } catch (error: any) {
+    await handlers.error(args, error);
+  }
+}
+
 export async function runMain<T extends ArgsDef = ArgsDef>(
   cmd: CommandDef<T>,
   opts: RunMainOptions = {},
 ) {
-  const rawArgs = opts.rawArgs || process.argv.slice(2);
-  const showUsage = opts.showUsage || _showUsage;
-  try {
-    if (rawArgs.includes("--help") || rawArgs.includes("-h")) {
-      await showUsage(...(await resolveSubCommand(cmd, rawArgs)));
-      process.exit(0);
-    } else if (rawArgs.length === 1 && rawArgs[0] === "--version") {
-      const meta =
-        typeof cmd.meta === "function" ? await cmd.meta() : await cmd.meta;
-      if (!meta?.version) {
-        throw new CLIError("No version specified", "E_NO_VERSION");
-      }
-      consola.log(meta.version);
-    } else {
-      await runCommand(cmd, { rawArgs });
-    }
-  } catch (error: any) {
-    const isCLIError = error instanceof CLIError;
-    if (!isCLIError) {
-      consola.error(error, "\n");
-    }
-    if (isCLIError) {
-      await showUsage(...(await resolveSubCommand(cmd, rawArgs)));
-    }
-    consola.error(error.message);
-    process.exit(1);
-  }
+  opts.showUsage = opts.showUsage || _showUsage;
+  await runRawMain(cmd, { command: handleCommand, error: handleError }, opts);
 }
 
 export function createMain<T extends ArgsDef = ArgsDef>(

--- a/src/usage.ts
+++ b/src/usage.ts
@@ -1,6 +1,6 @@
 import consola from "consola";
 import { colors } from "consola/utils";
-import { formatLineColumns, resolveValue } from "./_utils";
+import { resolveValue } from "./_utils";
 import type { ArgsDef, CommandDef } from "./types";
 import { resolveArgs } from "./args";
 
@@ -135,4 +135,23 @@ export async function renderUsage<T extends ArgsDef = ArgsDef>(
   }
 
   return usageLines.filter((l) => typeof l === "string").join("\n");
+}
+
+export function formatLineColumns(lines: string[][], linePrefix = "") {
+  const maxLengh: number[] = [];
+  for (const line of lines) {
+    for (const [i, element] of line.entries()) {
+      maxLengh[i] = Math.max(maxLengh[i] || 0, element.length);
+    }
+  }
+  return lines
+    .map((l) =>
+      l
+        .map(
+          (c, i) =>
+            linePrefix + c[i === 0 ? "padStart" : "padEnd"](maxLengh[i]),
+        )
+        .join("  "),
+    )
+    .join("\n");
 }


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org) 
-->

### 🔗 Linked issue

https://github.com/rolldown/rolldown/pull/754#pullrequestreview-1981812870
<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] 📖 Documentation (updates to the documentation, readme, or JSdoc annotations)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [x] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

This PR will provide low level API `runRawMain`.

This makes it possible to implement command execution and error handling in the user's real parent. It also exports useful helpers and utilities for `runRawMain` and `showUsage`.

When `showUsage` is specified for `runMain`, it allows tree-shaking of citty's `showUsage` and `renderUsage`.

The function name `runRawMain` may be less desirable.
I tried to be making `showUsage` (`renderUsage`) customizable, but the complexity of the current implementation made generalization hard.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
