### PR TITLE
fix: strict args

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -76,7 +76,7 @@ export type ParsedArgs<T extends ArgsDef = ArgsDef> = {
         [K in keyof T]: T[K] extends { type: "enum" } ? K : never;
       }[keyof T],
       | {
-          [K in keyof T]: T[K] extends { options: infer U } ? U : never;
+          [K in keyof T]: T[K] extends { options: Array<infer U> } ? U : never;
         }[keyof T]
       | undefined
     >,

--- a/src/types.ts
+++ b/src/types.ts
@@ -40,36 +40,54 @@ export type ArgsDef = Record<string, ArgDef>;
 
 export type Arg = ArgDef & { name: string; alias: string[] };
 
-export type ParsedArgs<T extends ArgsDef = ArgsDef> = { _: string[] } & Record<
-  { [K in keyof T]: T[K] extends { type: "positional" } ? K : never }[keyof T],
-  string
+export type RequiredArgs<T extends Record<string, any>, P> = {
+  [K in keyof T]: K extends P ? NonNullable<T[K]> : T[K];
+};
+
+export type ParsedArgs<T extends ArgsDef = ArgsDef> = {
+  _: string[];
+} & RequiredArgs<
+  Record<
+    {
+      [K in keyof T]: T[K] extends { type: "positional" } ? K : never;
+    }[keyof T],
+    string | undefined
+  > &
+    Record<
+      {
+        [K in keyof T]: T[K] extends { type: "string" } ? K : never;
+      }[keyof T],
+      string | undefined
+    > &
+    Record<
+      {
+        [K in keyof T]: T[K] extends { type: "number" } ? K : never;
+      }[keyof T],
+      number | undefined
+    > &
+    Record<
+      {
+        [K in keyof T]: T[K] extends { type: "boolean" } ? K : never;
+      }[keyof T],
+      boolean | undefined
+    > &
+    Record<
+      {
+        [K in keyof T]: T[K] extends { type: "enum" } ? K : never;
+      }[keyof T],
+      | {
+          [K in keyof T]: T[K] extends { options: infer U } ? U : never;
+        }[keyof T]
+      | undefined
+    >,
+  {
+    [K in keyof T]: T[K] extends
+      | { required: true }
+      | { default: string | number | boolean }
+      ? K
+      : never;
+  }[keyof T]
 > &
-  Record<
-    {
-      [K in keyof T]: T[K] extends { type: "string" } ? K : never;
-    }[keyof T],
-    string
-  > &
-  Record<
-    {
-      [K in keyof T]: T[K] extends { type: "number" } ? K : never;
-    }[keyof T],
-    number
-  > &
-  Record<
-    {
-      [K in keyof T]: T[K] extends { type: "boolean" } ? K : never;
-    }[keyof T],
-    boolean
-  > &
-  Record<
-    {
-      [K in keyof T]: T[K] extends { type: "enum" } ? K : never;
-    }[keyof T],
-    {
-      [K in keyof T]: T[K] extends { options: infer U } ? U : never;
-    }[keyof T]
-  > &
   Record<string, string | number | boolean | string[]>;
 
 // ----- Command -----


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org) 
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

#148 

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme, or JSdoc annotations)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

Resolves #148 

I noticed that citty didn't provide null-safety on `context.args` even `strict` is `true`, this will break some type checks. In this pr I make all args be nullable first, then make required and items with default values ​​non-nullable.

And `ParsedArgs` type has some errors when parsing enum, it just return the `options` array itself but the correct should be the type of items in the array. In this pr I just simplly fixed it, but the best fix should make the type more precise.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [x] I have updated the documentation accordingly. (N/A)
