### PR TITLE
test: exclude playground from coverage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,5 +21,5 @@ jobs:
       - run: pnpm install
       - run: pnpm lint
       - run: pnpm build
-      - run: pnpm vitest --coverage --coverage.explude playground
+      - run: pnpm vitest --coverage --coverage.exclude playground
       - uses: codecov/codecov-action@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,5 +21,5 @@ jobs:
       - run: pnpm install
       - run: pnpm lint
       - run: pnpm build
-      - run: pnpm vitest --coverage
+      - run: pnpm vitest --coverage --coverage.explude playground
       - uses: codecov/codecov-action@v4

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "prepack": "pnpm run build",
     "play": "jiti ./playground/cli.ts",
     "release": "pnpm test && changelogen --release --push && npm publish",
-    "test": "pnpm lint && vitest run --coverage"
+    "test": "pnpm lint && vitest run --coverage --coverage.exclude playground"
   },
   "dependencies": {
     "consola": "^3.2.3"


### PR DESCRIPTION
Hello 👋,

This PR add the flag `coverage.exclude` to the test coverage command to avoid to include the `playground` folder in the coverage report.

This PR also remove the playground coverage in the CI.