### PR TITLE
fix: parameter cannot start with a hyphen

### DIFF
--- a/src/_parser.ts
+++ b/src/_parser.ts
@@ -136,7 +136,7 @@ export function parseRawArgs<T = Default>(
       val =
         arg.slice(Math.max(0, ++idx)) ||
         i + 1 === len ||
-        ("" + args[i + 1]).charCodeAt(0) === 45 ||
+        (("" + args[i + 1]).charCodeAt(0) === 45 && !("" + args[i + 1]).includes(' ')) ||
         args[++i];
       arr = j === 2 ? [name] : name;
 


### PR DESCRIPTION
If there is a string parameter in the command, the string will not be able to start with a hyphen (-).
For example, ` --params "-a 192.168.1.1 -b -c"` will get empty params.
