### PR TITLE
feat!: parsed optionals and enum type safety 

### DIFF
--- a/src/command.ts
+++ b/src/command.ts
@@ -2,32 +2,9 @@ import type { CommandContext, CommandDef, ArgsDef } from "./types";
 import { CLIError, resolveValue } from "./_utils";
 import { parseArgs } from "./args";
 
-type DefineCommandOptions<Strict extends boolean = false> = {
-  /**
-   * Opt into accurate type inference
-   * - optional arguments (not required, default unset) can be `undefined`
-   * - enum arguments resolve to union of configured options
-   */
-  strict?: Strict;
-};
-
 export function defineCommand<const T extends ArgsDef = ArgsDef>(
-  def: CommandDef<T, true>,
-  options: DefineCommandOptions<true>,
-): CommandDef<T, true>;
-
-export function defineCommand<T extends ArgsDef = ArgsDef>(
-  def: CommandDef<T, false>,
-  options?: DefineCommandOptions<false>,
-): CommandDef<T, false>;
-
-export function defineCommand<
-  T extends ArgsDef = ArgsDef,
-  Strict extends boolean = false,
->(
-  def: CommandDef<T, Strict>,
-  options?: DefineCommandOptions<Strict>,
-): CommandDef<T, Strict> {
+  def: CommandDef<T>,
+): CommandDef<T> {
   return def;
 }
 

--- a/src/command.ts
+++ b/src/command.ts
@@ -2,9 +2,32 @@ import type { CommandContext, CommandDef, ArgsDef } from "./types";
 import { CLIError, resolveValue } from "./_utils";
 import { parseArgs } from "./args";
 
+type DefineCommandOptions<Strict extends boolean = false> = {
+  /**
+   * Opt into accurate type inference
+   * - optional arguments (not required, default unset) can be `undefined`
+   * - enum arguments resolve to union of configured options
+   */
+  strict?: Strict;
+};
+
+export function defineCommand<const T extends ArgsDef = ArgsDef>(
+  def: CommandDef<T, true>,
+  options: DefineCommandOptions<true>,
+): CommandDef<T, true>;
+
 export function defineCommand<T extends ArgsDef = ArgsDef>(
-  def: CommandDef<T>,
-): CommandDef<T> {
+  def: CommandDef<T, false>,
+  options?: DefineCommandOptions<false>,
+): CommandDef<T, false>;
+
+export function defineCommand<
+  T extends ArgsDef = ArgsDef,
+  Strict extends boolean = false,
+>(
+  def: CommandDef<T, Strict>,
+  options?: DefineCommandOptions<Strict>,
+): CommandDef<T, Strict> {
   return def;
 }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -44,11 +44,7 @@ export type Arg = ArgDef & { name: string; alias: string[] };
 
 // Args: Parsed
 
-type ResolveParsedArgType<
-  T extends ArgDef,
-  VT,
-  Strict extends boolean = false,
-> = T extends {
+type ResolveParsedArgType<T extends ArgDef, VT> = T extends {
   default?: any;
   required?: boolean;
 }
@@ -56,50 +52,31 @@ type ResolveParsedArgType<
     ? VT
     : T["required"] extends true
       ? VT
-      : Strict extends false
-        ? VT
-        : VT | undefined
-  : Strict extends false
-    ? VT
-    : VT | undefined;
+      : VT | undefined
+  : VT | undefined;
 
-type ParsedPositionalArg<
-  T extends ArgDef,
-  Strict extends boolean = false,
-> = T extends { type: "positional" }
-  ? ResolveParsedArgType<T, string, Strict>
+type ParsedPositionalArg<T extends ArgDef> = T extends { type: "positional" }
+  ? ResolveParsedArgType<T, string>
   : never;
 
-type ParsedStringArg<
-  T extends ArgDef,
-  Strict extends boolean = false,
-> = T extends { type: "string" }
-  ? ResolveParsedArgType<T, string, Strict>
+type ParsedStringArg<T extends ArgDef> = T extends { type: "string" }
+  ? ResolveParsedArgType<T, string>
   : never;
 
-type ParsedNumberArg<
-  T extends ArgDef,
-  Strict extends boolean = false,
-> = T extends { type: "number" }
-  ? ResolveParsedArgType<T, number, Strict>
+type ParsedNumberArg<T extends ArgDef> = T extends { type: "number" }
+  ? ResolveParsedArgType<T, number>
   : never;
 
-type ParsedBooleanArg<
-  T extends ArgDef,
-  Strict extends boolean = false,
-> = T extends { type: "boolean" }
-  ? ResolveParsedArgType<T, boolean, Strict>
+type ParsedBooleanArg<T extends ArgDef> = T extends { type: "boolean" }
+  ? ResolveParsedArgType<T, boolean>
   : never;
 
-type ParsedEnumArg<
-  T extends ArgDef,
-  Strict extends boolean = false,
-> = T extends {
+type ParsedEnumArg<T extends ArgDef> = T extends {
   type: "enum";
   options: infer U;
 }
   ? U extends Array<any>
-    ? ResolveParsedArgType<T, U[number], Strict>
+    ? ResolveParsedArgType<T, U[number]>
     : never
   : never;
 
@@ -107,16 +84,13 @@ type RawArgs = {
   _: string[];
 };
 
-export type ParsedArgs<
-  T extends ArgsDef = ArgsDef,
-  Strict extends boolean = false,
-> = RawArgs & {
+export type ParsedArgs<T extends ArgsDef = ArgsDef> = RawArgs & {
   [K in keyof T]:
-    | ParsedPositionalArg<T[K], Strict>
-    | ParsedStringArg<T[K], Strict>
-    | ParsedNumberArg<T[K], Strict>
-    | ParsedBooleanArg<T[K], Strict>
-    | ParsedEnumArg<T[K], Strict>;
+    | ParsedPositionalArg<T[K]>
+    | ParsedStringArg<T[K]>
+    | ParsedNumberArg<T[K]>
+    | ParsedBooleanArg<T[K]>
+    | ParsedEnumArg<T[K]>;
 } & Record<string, string | number | boolean | string[]>;
 
 // ----- Command -----
@@ -134,26 +108,20 @@ export interface CommandMeta {
 
 export type SubCommandsDef = Record<string, Resolvable<CommandDef<any>>>;
 
-export type CommandDef<
-  T extends ArgsDef = ArgsDef,
-  Strict extends boolean = false,
-> = {
+export type CommandDef<T extends ArgsDef = ArgsDef> = {
   meta?: Resolvable<CommandMeta>;
   args?: Resolvable<T>;
   subCommands?: Resolvable<SubCommandsDef>;
-  setup?: (context: CommandContext<T, Strict>) => any | Promise<any>;
-  cleanup?: (context: CommandContext<T, Strict>) => any | Promise<any>;
-  run?: (context: CommandContext<T, Strict>) => any | Promise<any>;
+  setup?: (context: CommandContext<T>) => any | Promise<any>;
+  cleanup?: (context: CommandContext<T>) => any | Promise<any>;
+  run?: (context: CommandContext<T>) => any | Promise<any>;
 };
 
-export type CommandContext<
-  T extends ArgsDef = ArgsDef,
-  Strict extends boolean = false,
-> = {
+export type CommandContext<T extends ArgsDef = ArgsDef> = {
   rawArgs: string[];
-  args: ParsedArgs<T, Strict>;
-  cmd: CommandDef<T, Strict>;
-  subCommand?: CommandDef<T, Strict>;
+  args: ParsedArgs<T>;
+  cmd: CommandDef<T>;
+  subCommand?: CommandDef<T>;
   data?: any;
 };
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -84,14 +84,21 @@ type RawArgs = {
   _: string[];
 };
 
-export type ParsedArgs<T extends ArgsDef = ArgsDef> = RawArgs & {
-  [K in keyof T]:
-    | ParsedPositionalArg<T[K]>
-    | ParsedStringArg<T[K]>
-    | ParsedNumberArg<T[K]>
-    | ParsedBooleanArg<T[K]>
-    | ParsedEnumArg<T[K]>;
-} & Record<string, string | number | boolean | string[]>;
+// prettier-ignore
+type ParsedArg<T extends ArgDef> =
+  T["type"] extends "positional" ? ParsedPositionalArg<T> :
+  T["type"] extends "boolean" ? ParsedBooleanArg<T> :
+  T["type"] extends "string" ? ParsedStringArg<T> :
+  T["type"] extends "number" ? ParsedNumberArg<T> :
+  T["type"] extends "enum" ? ParsedEnumArg<T> :
+  never;
+
+// prettier-ignore
+export type ParsedArgs<T extends ArgsDef = ArgsDef> = RawArgs &
+  { [K in keyof T]: ParsedArg<T[K]>; } & 
+  { [K in keyof T as T[K] extends { alias: string } ? T[K]["alias"] : never]: ParsedArg<T[K]> } &
+  { [K in keyof T as T[K] extends { alias: string[] } ? T[K]["alias"][number] : never]: ParsedArg<T[K]> } &
+  Record<string, string | number | boolean | string[]>;
 
 // ----- Command -----
 


### PR DESCRIPTION
<!--
PLEASE DO THIS BEFORE SUBMITTING A PR

1) Make sure there is an issue covering the problem or idea first. If not, please create one. Reference it in the PR via "resolves #12312312" 
2) Please keep your changes minimal and split them if you need to.
3) Ensure there is a minimal reproduction attached for bug fixes.

This will greatly help speed up the review process.

Thanks for your contribution ❤️
-->

I tried to make this PR as small as possible, these changes will cause type errors in projects that have relied on the parsed arguments never being `undefined`. I'm not very proficient with advanced types, and may have made obvious mistakes!

This PR changes the types to be more accurate:
* Parsed enum arguments resolve to a union type of its configured `option`
* Optional arguments (`required: false`, `default: undefined`) correctly resolve to `undefined`


```ts
defineCommand({
  args: {
    myEnum: { type: "enum", options: ["foo", "bar"] },
    myOptionalArg: { type: "string", required: false },
    myOptionalArgWithDefault: { type: "string", default: "my-default" },
  },
  run({ args }) {
    args.myEnum // "foo" | "bar" | undefined
    args.myOptionalArg // string | undefined
    args.myOptionalArgWithDefault // string
  }
})
```

These type changes make use of `defineCommand<const T extends ArgsDef = ArgsDef>` (note the addition of `const`), I'm not sure if this has other implications but it seems to be required for the enum inference.

While I was working on this I was looking to see if an issue exists about this type behavior but I couldn't find any, after already having a working solution I found that https://github.com/unjs/citty/pull/132 targets some of the same issues in a similar way, I took it as an example to restructure the `ParsedArgs` type.
