### PR TITLE
fix!: conditionally print negative boolean argument usage

### DIFF
--- a/src/usage.ts
+++ b/src/usage.ts
@@ -16,7 +16,7 @@ export async function showUsage<T extends ArgsDef = ArgsDef>(
 }
 
 // `no` prefix matcher (kebab-case or camelCase)
-const negativePrefixRe = /^no[\-[A-Z]/;
+const negativePrefixRe = /^no[-A-Z]/;
 
 export async function renderUsage<T extends ArgsDef = ArgsDef>(
   cmd: CommandDef<T>,


### PR DESCRIPTION
<!--
PLEASE DO THIS BEFORE SUBMITTING A PR

1) Make sure there is an issue covering the problem or idea first. If not, please create one. Reference it in the PR via "resolves #12312312" 
2) Please keep your changes minimal and split them if you need to.
3) Ensure there is a minimal reproduction attached for bug fixes.

This will greatly help speed up the review process.

Thanks for your contribution ❤️
-->

This is currently marked breaking (`fix!:`) but it doesn't functionally change usage, only the usage printing is changed, whether that is breaking is a bit subjective 🤔

This PR changes the argument usage text for **boolean** arguments:
* Normal usage is always printed and uses `description`
* Print negative usage when either
  * Argument is enabled by default
  * `negativeDescription` is defined (not empty)
* **Do not** print negative usage when
  * Argument name starts with negative prefix, either `no-` or `no[A-Z]`
* Negative usage description prints `negativeDescription` or empty text

Resolves #176
(FYI, I have changed the issue scope slightly)