### PR TITLE
fix: ensure process exits after running commands in main function

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -26,8 +26,10 @@ export async function runMain<T extends ArgsDef = ArgsDef>(
         throw new CLIError("No version specified", "E_NO_VERSION");
       }
       consola.log(meta.version);
+      process.exit(0);
     } else {
       await runCommand(cmd, { rawArgs });
+      process.exit(0);
     }
   } catch (error: any) {
     const isCLIError = error instanceof CLIError;


### PR DESCRIPTION
When running commands for you, I should include a clear and noticeable ending action to indicate completion. This approach is beneficial in cases where certain projects remain running persistently without exiting properly.