### PR TITLE
fix: show cli error message

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -33,6 +33,7 @@ export async function runMain<T extends ArgsDef = ArgsDef>(
     const isCLIError = error instanceof CLIError;
     if (isCLIError) {
       await showUsage(...(await resolveSubCommand(cmd, rawArgs)));
+      consola.error(error.message);
     } else {
       consola.error(error, "\n");
     }

--- a/test/usage.test.ts
+++ b/test/usage.test.ts
@@ -9,12 +9,9 @@ vi.mock("consola/utils", async () => {
     ...mod,
     colors: {
       ...mod.colors,
-      underline(val) {
-        return val;
-      },
-      bold(val) {
-        return val;
-      },
+      underline: (val) => val,
+      bold: (val) => val,
+      gray: (val) => val,
     },
   };
 });

--- a/test/usage.test.ts
+++ b/test/usage.test.ts
@@ -1,6 +1,20 @@
-import { expect, it, describe } from "vitest";
+import { expect, it, describe, vi } from "vitest";
 import { renderUsage } from "../src/usage";
 import { defineCommand } from "../src";
+
+vi.mock("consola/utils", async () => {
+const mod = await vi.importActual('consola/utils')
+
+return {
+  ...mod,
+  colors: {
+    ...mod.colors,
+    underline(val) {
+      return val
+    }
+  }
+}
+})
 
 describe("usage", () => {
   it("renders arguments", async () => {

--- a/test/usage.test.ts
+++ b/test/usage.test.ts
@@ -3,18 +3,18 @@ import { renderUsage } from "../src/usage";
 import { defineCommand } from "../src";
 
 vi.mock("consola/utils", async () => {
-const mod = await vi.importActual('consola/utils')
+  const mod = await vi.importActual("consola/utils");
 
-return {
-  ...mod,
-  colors: {
-    ...mod.colors,
-    underline(val) {
-      return val
-    }
-  }
-}
-})
+  return {
+    ...mod,
+    colors: {
+      ...mod.colors,
+      underline(val) {
+        return val;
+      },
+    },
+  };
+});
 
 describe("usage", () => {
   it("renders arguments", async () => {

--- a/test/usage.test.ts
+++ b/test/usage.test.ts
@@ -12,6 +12,9 @@ vi.mock("consola/utils", async () => {
       underline(val) {
         return val;
       },
+      bold(val) {
+        return val;
+      },
     },
   };
 });


### PR DESCRIPTION
~~This fixes the failing tests.~~ investigating..

I think the intention of https://github.com/unjs/citty/pull/167 was to show either the error message or the error with stack trace, but ended up removing the error message log for cli errors entirely? 🤔

before:

![image](https://github.com/user-attachments/assets/15ae5f4d-4b4f-4406-a263-fc7f7f2ffc02)

after: 

![image](https://github.com/user-attachments/assets/e3386d3f-dfcc-493d-8ca2-adf40fb2d4bb)
