### PR TITLE
feat: use `undefined` as fallback for `string` & `number` args with no values

### DIFF
--- a/src/_parser.ts
+++ b/src/_parser.ts
@@ -25,17 +25,17 @@ function toArr(any: any) {
 function toVal(out, key, val, opts) {
   let x;
   const old = out[key];
-  const nxt = ~opts.string.indexOf(key)
+  const nxt = opts.string.includes(key)
     ? val == undefined || val === true
       ? undefined
       : String(val)
-    : ~opts.number.indexOf(key)
+    : opts.number.includes(key)
       ? val == undefined || val === true
         ? undefined
         : val
       : typeof val === "boolean"
         ? val
-        : ~opts.boolean.indexOf(key)
+        : opts.boolean.includes(key)
           ? val === "false"
             ? false
             : val === "true" ||
@@ -127,7 +127,7 @@ export function parseRawArgs<T = Default>(
       out._.push(arg);
     } else if (arg.substring(j, j + 3) === "no-") {
       name = arg.slice(Math.max(0, j + 3));
-      if (strict && !~keys.indexOf(name)) {
+      if (strict && !keys.includes(name)) {
         return opts.unknown(arg);
       }
       out[name] = false;
@@ -148,7 +148,7 @@ export function parseRawArgs<T = Default>(
 
       for (idx = 0; idx < arr.length; idx++) {
         name = arr[idx];
-        if (strict && !~keys.indexOf(name)) {
+        if (strict && !keys.includes(name)) {
           return opts.unknown("-".repeat(j) + name);
         }
         toVal(out, name, idx + 1 < arr.length || val, opts);

--- a/src/_parser.ts
+++ b/src/_parser.ts
@@ -8,7 +8,6 @@ type Default = Dict<any>;
 export interface Options {
   boolean?: Arrayable<string>;
   string?: Arrayable<string>;
-  number?: Arrayable<string>;
   alias?: Dict<Arrayable<string>>;
   default?: Dict<any>;
   unknown?(flag: string): void;
@@ -29,20 +28,16 @@ function toVal(out, key, val, opts) {
     ? val == undefined || val === true
       ? undefined
       : String(val)
-    : opts.number.includes(key)
-      ? val == undefined || val === true
-        ? undefined
-        : val
-      : typeof val === "boolean"
-        ? val
-        : opts.boolean.includes(key)
-          ? val === "false"
-            ? false
-            : val === "true" ||
-              (out._.push(((x = +val), x * 0 === 0) ? x : val), !!val)
-          : ((x = +val), x * 0 === 0)
-            ? x
-            : val;
+    : typeof val === "boolean"
+      ? val
+      : opts.boolean.includes(key)
+        ? val === "false"
+          ? false
+          : val === "true" ||
+            (out._.push(((x = +val), x * 0 === 0) ? x : val), !!val)
+        : ((x = +val), x * 0 === 0)
+          ? x
+          : val;
   out[key] =
     old == undefined ? nxt : Array.isArray(old) ? old.concat(nxt) : [old, nxt];
 }
@@ -69,7 +64,6 @@ export function parseRawArgs<T = Default>(
   opts.alias = opts.alias || {};
   opts.string = toArr(opts.string);
   opts.boolean = toArr(opts.boolean);
-  opts.number = toArr(opts.number);
 
   if (alibi) {
     for (k in opts.alias) {

--- a/src/_parser.ts
+++ b/src/_parser.ts
@@ -8,6 +8,7 @@ type Default = Dict<any>;
 export interface Options {
   boolean?: Arrayable<string>;
   string?: Arrayable<string>;
+  number?: Arrayable<string>;
   alias?: Dict<Arrayable<string>>;
   default?: Dict<any>;
   unknown?(flag: string): void;
@@ -26,18 +27,22 @@ function toVal(out, key, val, opts) {
   const old = out[key];
   const nxt = ~opts.string.indexOf(key)
     ? val == undefined || val === true
-      ? ""
+      ? undefined
       : String(val)
-    : typeof val === "boolean"
-      ? val
-      : ~opts.boolean.indexOf(key)
-        ? val === "false"
-          ? false
-          : val === "true" ||
-            (out._.push(((x = +val), x * 0 === 0) ? x : val), !!val)
-        : ((x = +val), x * 0 === 0)
-          ? x
-          : val;
+    : ~opts.number.indexOf(key)
+      ? val == undefined || val === true
+        ? undefined
+        : val
+      : typeof val === "boolean"
+        ? val
+        : ~opts.boolean.indexOf(key)
+          ? val === "false"
+            ? false
+            : val === "true" ||
+              (out._.push(((x = +val), x * 0 === 0) ? x : val), !!val)
+          : ((x = +val), x * 0 === 0)
+            ? x
+            : val;
   out[key] =
     old == undefined ? nxt : Array.isArray(old) ? old.concat(nxt) : [old, nxt];
 }
@@ -64,6 +69,7 @@ export function parseRawArgs<T = Default>(
   opts.alias = opts.alias || {};
   opts.string = toArr(opts.string);
   opts.boolean = toArr(opts.boolean);
+  opts.number = toArr(opts.number);
 
   if (alibi) {
     for (k in opts.alias) {

--- a/src/args.ts
+++ b/src/args.ts
@@ -10,7 +10,6 @@ export function parseArgs<T extends ArgsDef = ArgsDef>(
   const parseOptions = {
     boolean: [] as string[],
     string: [] as string[],
-    number: [] as string[],
     enum: [] as (number | string)[],
     mixed: [] as string[],
     alias: {} as Record<string, string | string[]>,

--- a/test/parser.test.ts
+++ b/test/parser.test.ts
@@ -88,4 +88,16 @@ describe("parseRawArgs", () => {
       _: [],
     });
   });
+
+  it("handles arguments with no values", () => {
+    const args = ["--name", "--age"];
+    const opts = { string: ["name"], number: ["age"] };
+    const result = parseRawArgs(args, opts);
+
+    expect("name" in result).toBeTruthy();
+    expect("age" in result).toBeTruthy();
+
+    expect(result.name).toBeUndefined();
+    expect(result.age).toBeUndefined();
+  });
 });

--- a/test/parser.test.ts
+++ b/test/parser.test.ts
@@ -90,14 +90,18 @@ describe("parseRawArgs", () => {
   });
 
   it("handles arguments with no values", () => {
-    const args = ["--name", "--age"];
-    const opts = { string: ["name"], number: ["age"] };
+    const args = ["--name", "--age", "--specified", "--any"];
+    const opts = { string: ["name"], number: ["age"], boolean: ["specified"] };
     const result = parseRawArgs(args, opts);
 
     expect("name" in result).toBeTruthy();
     expect("age" in result).toBeTruthy();
+    expect("specified" in result).toBeTruthy();
+    expect("any" in result).toBeTruthy();
 
     expect(result.name).toBeUndefined();
     expect(result.age).toBeUndefined();
+    expect(result.specified).toBeTruthy();
+    expect(result.any).toBeTruthy();
   });
 });

--- a/test/parser.test.ts
+++ b/test/parser.test.ts
@@ -90,17 +90,15 @@ describe("parseRawArgs", () => {
   });
 
   it("handles arguments with no values", () => {
-    const args = ["--name", "--age", "--specified", "--any"];
-    const opts = { string: ["name"], number: ["age"], boolean: ["specified"] };
+    const args = ["--name", "--specified", "--any"];
+    const opts = { string: ["name"], boolean: ["specified"] };
     const result = parseRawArgs(args, opts);
 
     expect("name" in result).toBeTruthy();
-    expect("age" in result).toBeTruthy();
     expect("specified" in result).toBeTruthy();
     expect("any" in result).toBeTruthy();
 
     expect(result.name).toBeUndefined();
-    expect(result.age).toBeUndefined();
     expect(result.specified).toBeTruthy();
     expect(result.any).toBeTruthy();
   });


### PR DESCRIPTION
resolves #142

This PR changes the fallback for `string` & `number` args from `""` to `undefined`.

This change enables differentiation between user-specified values, such as: `test --config` vs `test --config ""`

Example:

```ts
  args: {
    name: {
      type: 'string',
    },
    age: {
      type: 'number',
    },
  },
```

Previously:

`test --name` => `ctx.args.name === ""`
`test --name ""` => `ctx.args.name === ""`
`test --age` => throws

Now:

`test --name` => `ctx.args.name === undefined` & `("name" in ctx.args) === true`
`test --name ""` => `ctx.args.name === ""`

`test --age` => `ctx.args.age === undefined` & `("age" in ctx.args) === true`

