### PR TITLE
chore: fix readme formatting

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 Elegant CLI Builder
 
 - Zero dependency
-- Fast and lightweight argument parser (based on native [node utils](arg parser](https://nodejs.org/api/util.html#utilparseargsconfig))
+- Fast and lightweight argument parser (based on native [Node.js `util.parseArgs`](https://nodejs.org/api/util.html#utilparseargsconfig))
 - Smart value parsing with typecast and boolean shortcuts
 - Nested sub-commands
 - Lazy and Async commands


### PR DESCRIPTION
Fixes broken markdown link syntax in argument parser description.

before:
<img width="738" height="169" alt="Screenshot 2026-02-07 at 7 56 36 AM" src="https://github.com/user-attachments/assets/9f653af8-8152-4810-91d2-2c41c340d836" />

after:

<img width="731" height="147" alt="Screenshot 2026-02-07 at 7 57 03 AM" src="https://github.com/user-attachments/assets/11488d22-f894-4a5a-b22f-c05c5fc1fac8" />
