### PR TITLE
feat: support alias for command names, resolves #152

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -96,6 +96,7 @@ export interface CommandMeta {
   version?: string;
   description?: string;
   hidden?: boolean;
+  alias?: string | string[];
 }
 
 // Command: Definition

--- a/src/usage.ts
+++ b/src/usage.ts
@@ -1,5 +1,5 @@
 import * as colors from "./_color.ts";
-import { formatLineColumns, resolveValue } from "./_utils.ts";
+import { formatLineColumns, resolveValue, toArray } from "./_utils.ts";
 import type { ArgsDef, CommandDef } from "./types.ts";
 import { resolveArgs } from "./args.ts";
 
@@ -98,7 +98,13 @@ export async function renderUsage<T extends ArgsDef = ArgsDef>(
       if (meta?.hidden) {
         continue;
       }
-      commandsLines.push([colors.cyan(name), meta?.description || ""]);
+      const aliases = meta?.alias ? toArray(meta.alias) : [];
+      commandsLines.push([
+        colors.cyan(
+          name + (aliases.length > 0 ? `, ${aliases.join(", ")}` : ""),
+        ),
+        meta?.description || "",
+      ]);
       commandNames.push(name);
     }
     usageLine.push(commandNames.join("|"));

--- a/test/alias.test.ts
+++ b/test/alias.test.ts
@@ -1,0 +1,83 @@
+import { describe, it, expect } from "vitest";
+import { defineCommand, runCommand } from "../src/index.js";
+
+describe("command alias", () => {
+  it("should resolve subcommand by alias", async () => {
+    let executed = false;
+    const sub = defineCommand({
+      meta: {
+        name: "sub",
+        alias: "s",
+      },
+      run: () => {
+        executed = true;
+      },
+    });
+
+    const root = defineCommand({
+      subCommands: {
+        sub,
+      },
+    });
+
+    await runCommand(root, { rawArgs: ["s"] });
+    expect(executed).toBe(true);
+  });
+
+  it("should resolve subcommand by alias array", async () => {
+    let executed = "";
+    const sub = defineCommand({
+      meta: {
+        name: "sub",
+        alias: ["s", "alias"],
+      },
+      run: () => {
+        executed = "sub";
+      },
+    });
+
+    const root = defineCommand({
+      subCommands: {
+        sub,
+      },
+    });
+
+    await runCommand(root, { rawArgs: ["s"] });
+    expect(executed).toBe("sub");
+
+    executed = "";
+    await runCommand(root, { rawArgs: ["alias"] });
+    expect(executed).toBe("sub");
+  });
+
+  it("should handle nested aliases", async () => {
+    let executed = false;
+    const leaf = defineCommand({
+      meta: {
+        name: "leaf",
+        alias: "l",
+      },
+      run: () => {
+        executed = true;
+      },
+    });
+    const sub = defineCommand({
+      meta: {
+        name: "sub",
+        alias: "s",
+      },
+      subCommands: {
+        leaf,
+      },
+    });
+
+    const root = defineCommand({
+      subCommands: {
+        sub,
+      },
+    });
+
+    await runCommand(root, { rawArgs: ["s", "l"] });
+    expect(executed).toBe(true);
+  });
+});

--- a/test/usage.test.ts
+++ b/test/usage.test.ts
@@ -304,4 +304,25 @@ describe("usage", () => {
       Use parent-command child-command <command> --help for more information about a command."
     `);
   });
+  it("renders subcommands with aliases", async () => {
+    const command = defineCommand({
+      meta: {
+        name: "Commander",
+        description: "A command",
+      },
+      subCommands: {
+        sub: defineCommand({
+          meta: {
+            name: "Subcommander",
+            description: "A subcommand",
+            alias: ["s", "alias"],
+          },
+        }),
+      },
+    });
+
+    const usage = await renderUsage(command);
+
+    expect(usage).toContain("sub, s, alias    A subcommand");
+  });
 });


### PR DESCRIPTION
### 🔗 Linked issue

add alias support #152

### ❓ Type of change

- [x] ✨ New feature (a non-breaking change that adds functionality)

### 📚 Description

Support providing a (short) alias for a command, resolve based on it, and render the alias as part of the usage output.

```typescript
const install = defineCommand({
  meta: {
    name: "install",
    alias: "i", // ← this is new ✨
    description: "Install dependencies",
  },
  run() {
    console.log("Installing...");
  },
});

const main = defineCommand({
  meta: {
    name: "my-cli",
    description: "My Awesome CLI",
  },
  subCommands: {
    install,
  },
});

runMain(main);
```

```text
My Awesome CLI (my-cli)

USAGE my-cli install

COMMANDS

  install, i    Install dependencies
...
```

### 📝 Checklist

- [x] I have linked an issue or discussion.
- [x] I have updated the documentation accordingly.

