### PR TITLE
fix: propagate --no- negation to aliases and main option

### DIFF
--- a/src/_parser.ts
+++ b/src/_parser.ts
@@ -142,9 +142,24 @@ export function parseRawArgs<T = Record<string, any>>(
     (out as any)[key] = value;
   }
 
-  // Apply negated flags
+  // Apply negated flags (with alias resolution)
   for (const [name] of Object.entries(negatedFlags)) {
+    // Set the flag itself
     (out as any)[name] = false;
+
+    // Resolve to main option and apply there too (handles --no-alias)
+    const mainName = aliasToMain.get(name);
+    if (mainName) {
+      (out as any)[mainName] = false;
+    }
+
+    // Also apply to all aliases of this name (handles --no-main for aliases)
+    const aliases = mainToAliases.get(name);
+    if (aliases) {
+      for (const alias of aliases) {
+        (out as any)[alias] = false;
+      }
+    }
   }
 
   // Propagate values between aliases

--- a/test/parser.test.ts
+++ b/test/parser.test.ts
@@ -72,4 +72,44 @@ describe("parseRawArgs", () => {
       _: [],
     });
   });
+
+  it("handles --no- negation on main option", () => {
+    const result = parseRawArgs(["--no-verbose"], {
+      boolean: ["verbose"],
+      default: { verbose: true },
+    });
+
+    expect(result).toEqual({
+      _: [],
+      verbose: false,
+    });
+  });
+
+  it("handles --no- negation on alias and propagates to main option", () => {
+    const result = parseRawArgs(["--no-v"], {
+      boolean: ["verbose"],
+      alias: { v: ["verbose"] },
+      default: { verbose: true },
+    });
+
+    expect(result).toEqual({
+      _: [],
+      v: false,
+      verbose: false,
+    });
+  });
+
+  it("handles --no- negation on main option and propagates to aliases", () => {
+    const result = parseRawArgs(["--no-verbose"], {
+      boolean: ["verbose"],
+      alias: { v: ["verbose"] },
+      default: { verbose: true },
+    });
+
+    expect(result).toEqual({
+      _: [],
+      v: false,
+      verbose: false,
+    });
+  });
 });


### PR DESCRIPTION
## Summary

Fixes #209 

When using `--no-flag` syntax with an alias (e.g., `--no-v` where `v` is an alias for `verbose`), the negation now correctly propagates to both the alias and the main option, overwriting any default values.

## Problem

Previously, `--no-v` would set `v=false` but leave `verbose=true` (if `verbose` had a default of `true`) because the propagation logic only copied values when the target was `undefined`.

For example:
```js
const result = parseRawArgs(['--no-v'], {
  boolean: ['verbose'],
  alias: { v: ['verbose'] },
  default: { verbose: true },
});
// Before: { v: false, verbose: true }  // Bug!
// After:  { v: false, verbose: false } // Fixed!
```

## Solution

When applying negated flags, resolve to both:
1. The main option name (if the flag is an alias)
2. All aliases (if the flag is the main option)

This ensures negated flags work consistently regardless of whether you use `--no-main` or `--no-alias`.

## Tests

Added 3 test cases:
- `--no-` negation on main option
- `--no-` negation on alias propagates to main option
- `--no-` negation on main option propagates to aliases

All 57 tests pass.