### PR TITLE
test: reproduce issue with short option (alias) and `=`

### DIFF
--- a/test/parser.test.ts
+++ b/test/parser.test.ts
@@ -36,8 +36,8 @@ describe("parseRawArgs", () => {
 
     expect(result).toEqual({
       _: [],
-      n: "John",
-      name: "John",
+      n: "=John",
+      name: "=John",
     });
   });
 

--- a/test/parser.test.ts
+++ b/test/parser.test.ts
@@ -26,7 +26,7 @@ describe("parseRawArgs", () => {
     });
   });
 
-  it("handles -<arg>=<value> with alias", () => {
+  it.fails("handles -<arg>=<value> with alias", () => {
     const result = parseRawArgs(["-n=John"], {
       string: ["name"],
       alias: {
@@ -36,8 +36,8 @@ describe("parseRawArgs", () => {
 
     expect(result).toEqual({
       _: [],
-      n: "=John",
-      name: "=John",
+      n: "John",
+      name: "John",
     });
   });
 

--- a/test/parser.test.ts
+++ b/test/parser.test.ts
@@ -60,8 +60,6 @@ describe("parseRawArgs", () => {
     });
   });
 
-
-
   it("handles boolean flags", () => {
     const result = parseRawArgs(["--flag"], { boolean: ["flag"] });
 

--- a/test/parser.test.ts
+++ b/test/parser.test.ts
@@ -15,31 +15,31 @@ describe("parseRawArgs", () => {
     });
   });
 
-  it('handles --<arg>=<value>', ()=>{
+  it("handles --<arg>=<value>", () => {
     const result = parseRawArgs(["--name=John"], {
-      string: ["name"]
+      string: ["name"],
     });
 
     expect(result).toEqual({
       _: [],
-      name: "John"
-    })
-  })
+      name: "John",
+    });
+  });
 
-  it('handles -<arg>=<value> with alias', ()=>{
+  it("handles -<arg>=<value> with alias", () => {
     const result = parseRawArgs(["-n=John"], {
       string: ["name"],
       alias: {
-        n: ["name"]
-      }
-    })
+        n: ["name"],
+      },
+    });
 
     expect(result).toEqual({
       _: [],
       n: "John",
       name: "John",
-    })
-  })
+    });
+  });
 
   it("handles default values", () => {
     const result = parseRawArgs([], { default: { name: "Default" } });

--- a/test/parser.test.ts
+++ b/test/parser.test.ts
@@ -15,6 +15,32 @@ describe("parseRawArgs", () => {
     });
   });
 
+  it('handles --<arg>=<value>', ()=>{
+    const result = parseRawArgs(["--name=John"], {
+      string: ["name"]
+    });
+
+    expect(result).toEqual({
+      _: [],
+      name: "John"
+    })
+  })
+
+  it('handles -<arg>=<value> with alias', ()=>{
+    const result = parseRawArgs(["-n=John"], {
+      string: ["name"],
+      alias: {
+        n: ["name"]
+      }
+    })
+
+    expect(result).toEqual({
+      _: [],
+      n: "John",
+      name: "John",
+    })
+  })
+
   it("handles default values", () => {
     const result = parseRawArgs([], { default: { name: "Default" } });
 
@@ -33,6 +59,8 @@ describe("parseRawArgs", () => {
       name: "John",
     });
   });
+
+
 
   it("handles boolean flags", () => {
     const result = parseRawArgs(["--flag"], { boolean: ["flag"] });

--- a/test/parser.test.ts
+++ b/test/parser.test.ts
@@ -26,7 +26,7 @@ describe("parseRawArgs", () => {
     });
   });
 
-  it.fails("handles -<arg>=<value> with alias", () => {
+  it.fails("handles -<arg>=<value> with alias (#237)", () => {
     const result = parseRawArgs(["-n=John"], {
       string: ["name"],
       alias: {


### PR DESCRIPTION
<!--
PLEASE DO THIS BEFORE SUBMITTING A PR

1) Make sure there is an issue covering the problem or idea first. If not, please create one. Reference it in the PR via "resolves #12312312" 
2) Please keep your changes minimal and split them if you need to.
3) Ensure there is a minimal reproduction attached for bug fixes.

This will greatly help speed up the review process.

Thanks for your contribution ❤️
-->

This test reproduces https://github.com/nuxt/nuxt/issues/34430 / https://github.com/unjs/citty/issues/237

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added tests verifying parsing of command-line arguments using assignment syntax (e.g., --arg=value), ensuring correct name/value extraction.
  * Added tests confirming short-form aliases with assignment syntax (e.g., -a=value) are recognized and expanded to full option names, producing both alias and full-name mappings.
  * Coverage is additive; no existing behavior or public interfaces were changed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->