### PR TITLE
feat: pass setup() return value to run() and cleanup()

### DIFF
--- a/playground/db.ts
+++ b/playground/db.ts
@@ -18,7 +18,7 @@ const main = defineCommand({
       default: "10",
     },
   },
-  async setup() {
+  async setup(_ctx) {
     const client = new DatabaseClient();
     await client.connect();
     return { client };

--- a/playground/db.ts
+++ b/playground/db.ts
@@ -1,0 +1,59 @@
+import { defineCommand, runMain } from "../src/index.ts";
+
+const main = defineCommand({
+  meta: {
+    name: "db",
+    version: "1.0.0",
+    description: "Database query tool",
+  },
+  args: {
+    table: {
+      type: "positional",
+      description: "Table name to query",
+      required: true,
+    },
+    limit: {
+      type: "string",
+      description: "Max rows to return",
+      default: "10",
+    },
+  },
+  async setup() {
+    const client = new DatabaseClient();
+    await client.connect();
+    return { client };
+  },
+  async run({ args }, { client }) {
+    const rows = await client.query(`SELECT * FROM ${args.table} LIMIT ${args.limit}`);
+    console.log(rows);
+  },
+  async cleanup(_context, { client }) {
+    await client.disconnect();
+  },
+});
+
+// Stub database client
+class DatabaseClient {
+  connected = false;
+
+  async connect() {
+    this.connected = true;
+    console.log("[db] Connected");
+  }
+
+  async query(sql: string) {
+    if (!this.connected) throw new Error("Not connected");
+    console.log(`[db] Query: ${sql}`);
+    return [
+      { id: 1, name: "Alice" },
+      { id: 2, name: "Bob" },
+    ];
+  }
+
+  async disconnect() {
+    this.connected = false;
+    console.log("[db] Disconnected");
+  }
+}
+
+runMain(main);

--- a/src/command.ts
+++ b/src/command.ts
@@ -22,7 +22,7 @@ export async function runCommand<T extends ArgsDef = ArgsDef, S = void>(
   const cmdArgs = await resolveValue(cmd.args || {});
   const parsedArgs = parseArgs<T>(opts.rawArgs, cmdArgs);
 
-  const context: CommandContext<T, S> = {
+  const context: CommandContext<T> = {
     rawArgs: opts.rawArgs,
     args: parsedArgs,
     data: opts.data,

--- a/src/command.ts
+++ b/src/command.ts
@@ -3,9 +3,9 @@ import { CLIError, resolveValue } from "./_utils.ts";
 import { parseArgs } from "./args.ts";
 import { cyan } from "./_color.ts";
 
-export function defineCommand<const T extends ArgsDef = ArgsDef>(
-  def: CommandDef<T>,
-): CommandDef<T> {
+export function defineCommand<const T extends ArgsDef = ArgsDef, S = void>(
+  def: CommandDef<T, S>,
+): CommandDef<T, S> {
   return def;
 }
 
@@ -15,14 +15,14 @@ export interface RunCommandOptions {
   showUsage?: boolean;
 }
 
-export async function runCommand<T extends ArgsDef = ArgsDef>(
-  cmd: CommandDef<T>,
+export async function runCommand<T extends ArgsDef = ArgsDef, S = void>(
+  cmd: CommandDef<T, S>,
   opts: RunCommandOptions,
 ): Promise<{ result: unknown }> {
   const cmdArgs = await resolveValue(cmd.args || {});
   const parsedArgs = parseArgs<T>(opts.rawArgs, cmdArgs);
 
-  const context: CommandContext<T> = {
+  const context: CommandContext<T, S> = {
     rawArgs: opts.rawArgs,
     args: parsedArgs,
     data: opts.data,
@@ -30,8 +30,9 @@ export async function runCommand<T extends ArgsDef = ArgsDef>(
   };
 
   // Setup hook
+  let setupResult: S | undefined;
   if (typeof cmd.setup === "function") {
-    await cmd.setup(context);
+    setupResult = await cmd.setup(context);
   }
 
   // Handle sub command
@@ -58,21 +59,21 @@ export async function runCommand<T extends ArgsDef = ArgsDef>(
 
     // Handle main command
     if (typeof cmd.run === "function") {
-      result = await cmd.run(context);
+      result = await cmd.run(context, setupResult as S);
     }
   } finally {
     if (typeof cmd.cleanup === "function") {
-      await cmd.cleanup(context);
+      await cmd.cleanup(context, setupResult as S);
     }
   }
   return { result };
 }
 
-export async function resolveSubCommand<T extends ArgsDef = ArgsDef>(
-  cmd: CommandDef<T>,
+export async function resolveSubCommand<T extends ArgsDef = ArgsDef, S = void>(
+  cmd: CommandDef<T, S>,
   rawArgs: string[],
-  parent?: CommandDef<T>,
-): Promise<[CommandDef<T>, CommandDef<T>?]> {
+  parent?: CommandDef<T, S>,
+): Promise<[CommandDef<T, S>, CommandDef<T, S>?]> {
   const subCommands = await resolveValue(cmd.subCommands);
   if (subCommands && Object.keys(subCommands).length > 0) {
     const subCommandArgIndex = rawArgs.findIndex((arg) => !arg.startsWith("-"));

--- a/src/main.ts
+++ b/src/main.ts
@@ -8,8 +8,8 @@ export interface RunMainOptions {
   showUsage?: typeof _showUsage;
 }
 
-export async function runMain<T extends ArgsDef = ArgsDef>(
-  cmd: CommandDef<T>,
+export async function runMain<T extends ArgsDef = ArgsDef, S = void>(
+  cmd: CommandDef<T, S>,
   opts: RunMainOptions = {},
 ) {
   const rawArgs = opts.rawArgs || process.argv.slice(2);
@@ -39,8 +39,8 @@ export async function runMain<T extends ArgsDef = ArgsDef>(
   }
 }
 
-export function createMain<T extends ArgsDef = ArgsDef>(
-  cmd: CommandDef<T>,
+export function createMain<T extends ArgsDef = ArgsDef, S = void>(
+  cmd: CommandDef<T, S>,
 ): (opts?: RunMainOptions) => Promise<void> {
   return (opts: RunMainOptions = {}) => runMain(cmd, opts);
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -99,16 +99,16 @@ export type CommandDef<T extends ArgsDef = ArgsDef, S = void> = {
   meta?: Resolvable<CommandMeta>;
   args?: Resolvable<T>;
   subCommands?: Resolvable<SubCommandsDef>;
-  setup?: (context: CommandContext<T, S>) => S | Promise<S>;
-  cleanup?: (context: CommandContext<T, S>, setupResult: NoInfer<S>) => any | Promise<any>;
-  run?: (context: CommandContext<T, S>, setupResult: NoInfer<S>) => any | Promise<any>;
+  setup?: (context: CommandContext<T>) => S | Promise<S>;
+  cleanup?: (context: CommandContext<T>, setupResult: NoInfer<S>) => any | Promise<any>;
+  run?: (context: CommandContext<T>, setupResult: NoInfer<S>) => any | Promise<any>;
 };
 
-export type CommandContext<T extends ArgsDef = ArgsDef, S = void> = {
+export type CommandContext<T extends ArgsDef = ArgsDef> = {
   rawArgs: string[];
   args: ParsedArgs<T>;
-  cmd: CommandDef<T, S>;
-  subCommand?: CommandDef<T, S>;
+  cmd: CommandDef<T, any>;
+  subCommand?: CommandDef<T, any>;
   data?: any;
 };
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -93,22 +93,22 @@ export interface CommandMeta {
 
 // Command: Definition
 
-export type SubCommandsDef = Record<string, Resolvable<CommandDef<any>>>;
+export type SubCommandsDef = Record<string, Resolvable<CommandDef<any, any>>>;
 
-export type CommandDef<T extends ArgsDef = ArgsDef> = {
+export type CommandDef<T extends ArgsDef = ArgsDef, S = void> = {
   meta?: Resolvable<CommandMeta>;
   args?: Resolvable<T>;
   subCommands?: Resolvable<SubCommandsDef>;
-  setup?: (context: CommandContext<T>) => any | Promise<any>;
-  cleanup?: (context: CommandContext<T>) => any | Promise<any>;
-  run?: (context: CommandContext<T>) => any | Promise<any>;
+  setup?: (context: CommandContext<T, S>) => S | Promise<S>;
+  cleanup?: (context: CommandContext<T, S>, setupResult: NoInfer<S>) => any | Promise<any>;
+  run?: (context: CommandContext<T, S>, setupResult: NoInfer<S>) => any | Promise<any>;
 };
 
-export type CommandContext<T extends ArgsDef = ArgsDef> = {
+export type CommandContext<T extends ArgsDef = ArgsDef, S = void> = {
   rawArgs: string[];
   args: ParsedArgs<T>;
-  cmd: CommandDef<T>;
-  subCommand?: CommandDef<T>;
+  cmd: CommandDef<T, S>;
+  subCommand?: CommandDef<T, S>;
   data?: any;
 };
 

--- a/src/usage.ts
+++ b/src/usage.ts
@@ -3,9 +3,9 @@ import { formatLineColumns, resolveValue } from "./_utils.ts";
 import type { ArgsDef, CommandDef } from "./types.ts";
 import { resolveArgs } from "./args.ts";
 
-export async function showUsage<T extends ArgsDef = ArgsDef>(
-  cmd: CommandDef<T>,
-  parent?: CommandDef<T>,
+export async function showUsage<T extends ArgsDef = ArgsDef, S = void>(
+  cmd: CommandDef<T, S>,
+  parent?: CommandDef<T, S>,
 ) {
   try {
     console.log((await renderUsage(cmd, parent)) + "\n");
@@ -17,9 +17,9 @@ export async function showUsage<T extends ArgsDef = ArgsDef>(
 // `no` prefix matcher (kebab-case or camelCase)
 const negativePrefixRe = /^no[-A-Z]/;
 
-export async function renderUsage<T extends ArgsDef = ArgsDef>(
-  cmd: CommandDef<T>,
-  parent?: CommandDef<T>,
+export async function renderUsage<T extends ArgsDef = ArgsDef, S = void>(
+  cmd: CommandDef<T, S>,
+  parent?: CommandDef<T, S>,
 ) {
   const cmdMeta = await resolveValue(cmd.meta || {});
   const cmdArgs = resolveArgs(await resolveValue(cmd.args || {}));


### PR DESCRIPTION
Closes https://github.com/unjs/citty/issues/92

## Summary

- Add a generic `S` parameter to `CommandDef` that captures the return type of `setup()`
- Forward the setup result as the 2nd argument to `run()` and `cleanup()`
- Uses `NoInfer<S>` so the type is inferred solely from `setup()`'s return type
- Defaults to `void` for backward compatibility

## Motivation

This separates command-internal state (e.g. a database connection opened in `setup()` and closed in `cleanup()`) from consumer-provided data on `context.data`. The 2nd argument makes it clear what comes from the command lifecycle vs what was passed in externally.

### Before

```ts
defineCommand({
  setup(context) {
    // return value was ignored
    context.data = { client: new DatabaseClient() };
  },
  run(context) {
    // no type safety, mixed with consumer data
    context.data.client.query("...");
  },
});
```

### After

```ts
defineCommand({
  async setup() {
    const client = new DatabaseClient();
    await client.connect();
    return { client }; // return type inferred as S
  },
  async run({ args }, { client }) {
    // fully typed, separate from context.data
    await client.query(`SELECT * FROM ${args.table}`);
  },
  async cleanup(_context, { client }) {
    await client.disconnect();
  },
});
```

## Test plan

- [ ] Verify `setup()` return value is passed to `run()` and `cleanup()`
- [ ] Verify type inference works (hover over 2nd arg in editor)
- [ ] Verify backward compatibility (commands without `setup` still work)
- [ ] Run `node playground/db.ts users` for a working demo

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a "db" playground command for querying tables with a configurable row limit.

* **Refactor**
  * Improved command lifecycle handling so setup results flow through run and cleanup, enhancing extensibility and reliability of command execution and usage rendering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->