### PR TITLE
fix(main): allow user-defined `-h`, `--help`, `-v`, `--version` args

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -1,6 +1,6 @@
 import type { ArgsDef, CommandDef } from "./types.ts";
 import { resolveSubCommand, runCommand } from "./command.ts";
-import { CLIError } from "./_utils.ts";
+import { CLIError, resolveValue, toArray } from "./_utils.ts";
 import { showUsage as _showUsage } from "./usage.ts";
 
 export interface RunMainOptions {
@@ -15,10 +15,11 @@ export async function runMain<T extends ArgsDef = ArgsDef>(
   const rawArgs = opts.rawArgs || process.argv.slice(2);
   const showUsage = opts.showUsage || _showUsage;
   try {
-    if (rawArgs.includes("--help") || rawArgs.includes("-h")) {
+    const builtinFlags = await _resolveBuiltinFlags(cmd);
+    if (builtinFlags.help.length > 0 && rawArgs.some((arg) => builtinFlags.help.includes(arg))) {
       await showUsage(...(await resolveSubCommand(cmd, rawArgs)));
       process.exit(0);
-    } else if (rawArgs.length === 1 && rawArgs[0] === "--version") {
+    } else if (rawArgs.length === 1 && builtinFlags.version.includes(rawArgs[0]!)) {
       const meta = typeof cmd.meta === "function" ? await cmd.meta() : await cmd.meta;
       if (!meta?.version) {
         throw new CLIError("No version specified", "E_NO_VERSION");
@@ -43,4 +44,41 @@ export function createMain<T extends ArgsDef = ArgsDef>(
   cmd: CommandDef<T>,
 ): (opts?: RunMainOptions) => Promise<void> {
   return (opts: RunMainOptions = {}) => runMain(cmd, opts);
+}
+
+// --- internal ---
+
+async function _resolveBuiltinFlags<T extends ArgsDef>(
+  cmd: CommandDef<T>,
+): Promise<{ help: string[]; version: string[] }> {
+  const argsDef = await resolveValue(cmd.args || ({} as ArgsDef));
+  const userNames = new Set<string>();
+  const userAliases = new Set<string>();
+  for (const [name, def] of Object.entries(argsDef)) {
+    userNames.add(name);
+    for (const alias of toArray((def as any).alias)) {
+      userAliases.add(alias);
+    }
+  }
+  return {
+    help: _getBuiltinFlags("help", "h", userNames, userAliases),
+    version: _getBuiltinFlags("version", "v", userNames, userAliases),
+  };
+}
+
+function _getBuiltinFlags(
+  long: string,
+  short: string,
+  userNames: Set<string>,
+  userAliases: Set<string>,
+): string[] {
+  const hasLong = userNames.has(long) || userAliases.has(long);
+  if (hasLong) {
+    return [];
+  }
+  const hasShort = userNames.has(short) || userAliases.has(short);
+  if (hasShort) {
+    return [`--${long}`];
+  }
+  return [`--${long}`, `-${short}`];
 }

--- a/test/main.test.ts
+++ b/test/main.test.ts
@@ -166,6 +166,131 @@ describe("resolveSubCommand", () => {
   });
 });
 
+describe("builtin flag conflicts", () => {
+  vi.spyOn(process, "exit").mockImplementation(() => 0 as never);
+
+  const runMock = vi.fn();
+
+  // -- help --
+
+  it("allows -h alias to be used by user args (e.g. --host)", async () => {
+    const command = defineCommand({
+      args: {
+        host: {
+          type: "string",
+          alias: "h",
+          description: "Host to bind",
+        },
+      },
+      run: ({ args }) => {
+        runMock(args.host);
+      },
+    });
+
+    await runMain(command, { rawArgs: ["-h", "localhost"] });
+
+    expect(runMock).toHaveBeenCalledWith("localhost");
+  });
+
+  it("still supports --help when -h is taken by user args", async () => {
+    const consoleMock = vi.spyOn(console, "log").mockImplementation(() => undefined);
+
+    const command = defineCommand({
+      meta: { name: "test", description: "Test" },
+      args: {
+        host: {
+          type: "string",
+          alias: "h",
+        },
+      },
+    });
+
+    await runMain(command, { rawArgs: ["--help"] });
+
+    const usage = await renderUsage(command);
+    expect(consoleMock).toHaveBeenCalledWith(usage + "\n");
+    consoleMock.mockRestore();
+  });
+
+  it("disables builtin help when user defines --help arg", async () => {
+    const command = defineCommand({
+      args: {
+        help: {
+          type: "boolean",
+          description: "Custom help",
+        },
+      },
+      run: ({ args }) => {
+        runMock(args.help);
+      },
+    });
+
+    await runMain(command, { rawArgs: ["--help"] });
+
+    expect(runMock).toHaveBeenCalledWith(true);
+  });
+
+  // -- version --
+
+  it("allows -v alias to be used by user args (e.g. --verbose)", async () => {
+    const command = defineCommand({
+      meta: { version: "1.0.0" },
+      args: {
+        verbose: {
+          type: "boolean",
+          alias: "v",
+          description: "Verbose output",
+        },
+      },
+      run: ({ args }) => {
+        runMock(args.verbose);
+      },
+    });
+
+    await runMain(command, { rawArgs: ["-v"] });
+
+    expect(runMock).toHaveBeenCalledWith(true);
+  });
+
+  it("still supports --version when -v is taken by user args", async () => {
+    const consoleMock = vi.spyOn(console, "log").mockImplementation(() => undefined);
+
+    const command = defineCommand({
+      meta: { version: "1.0.0" },
+      args: {
+        verbose: {
+          type: "boolean",
+          alias: "v",
+        },
+      },
+    });
+
+    await runMain(command, { rawArgs: ["--version"] });
+
+    expect(consoleMock).toHaveBeenCalledWith("1.0.0");
+    consoleMock.mockRestore();
+  });
+
+  it("disables builtin version when user defines --version arg", async () => {
+    const command = defineCommand({
+      meta: { version: "1.0.0" },
+      args: {
+        version: {
+          type: "boolean",
+          description: "Custom version",
+        },
+      },
+      run: ({ args }) => {
+        runMock(args.version);
+      },
+    });
+
+    await runMain(command, { rawArgs: ["--version"] });
+
+    expect(runMock).toHaveBeenCalledWith(true);
+  });
+});
+
 describe("createMain", () => {
   it("creates and returns a function", () => {
     const main = createMain(defineCommand({}));


### PR DESCRIPTION
## Summary

When user args conflict with built-in flags, citty yields gracefully:
- `-h` taken (e.g. `--host -h`) → only `--help` triggers built-in help
- `--help` taken → built-in help fully disabled
- `-v` taken (e.g. `--verbose -v`) → only `--version` triggers built-in version
- `--version` taken → built-in version fully disabled

Closes #232

## Test plan

- [x] `-h` alias passes through to user's `--host` arg
- [x] `--help` still triggers built-in help when only `-h` is taken
- [x] Built-in help fully disabled when user defines `--help` arg
- [x] `-v` alias passes through to user's `--verbose` arg
- [x] `--version` still triggers built-in version when only `-v` is taken
- [x] Built-in version fully disabled when user defines `--version` arg
- [x] All existing tests pass (63/63)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved help and version flag handling so built-in help/version remain available when user-defined flags conflict with -h/-v or --help/--version.

* **Tests**
  * Added comprehensive tests for help/version flag conflicts, covering cases where short or long flags are overridden by user arguments and ensuring correct behavior for usage and version output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->