### PR TITLE
fix(args): do not use node:util parseArgs default to allow alias overrides

### DIFF
--- a/src/_parser.ts
+++ b/src/_parser.ts
@@ -82,7 +82,7 @@ export function parseRawArgs<T = Record<string, any>>(
       const type = getType(name);
       options[name] = {
         type,
-        default: defaults[name],
+        // default: defaults[name],
       };
     }
   }
@@ -169,6 +169,18 @@ export function parseRawArgs<T = Record<string, any>>(
     }
     if ((out as any)[main] !== undefined && (out as any)[alias] === undefined) {
       (out as any)[alias] = (out as any)[main];
+    }
+  }
+
+  for (const [name, defaultValue] of Object.entries(defaults)) {
+    if ((out as any)[name] === undefined) {
+      (out as any)[name] = defaultValue;
+    }
+    const aliases = mainToAliases.get(name) || [];
+    for (const alias of aliases) {
+      if ((out as any)[alias] === undefined) {
+        (out as any)[alias] = defaultValue;
+      }
     }
   }
 

--- a/test/args.test.ts
+++ b/test/args.test.ts
@@ -99,4 +99,15 @@ describe("args", () => {
     expect(parsed.userName).toBe("Jane");
     expect(parsed._).toEqual([]);
   });
+
+  it("should override camelCase default when using kebab-case cli arg", () => {
+    const definition: ArgsDef = {
+      userName: { type: "string", default: "defaultUser" },
+    };
+    const rawArgs = ["--user-name", "Jane"];
+
+    const parsed = parseArgs(rawArgs, definition);
+
+    expect(parsed.userName).toBe("Jane");
+  });
 });


### PR DESCRIPTION
## Summary
Fixes an issue where providing the kebab-case CLI variant of an argument does not override its default when defined in camelCase.

## Problem
Fixes #227.
When parsing arguments,  registers aliases (so  acts as an alias to ). However, it also forwards  values down to the underlying  from .

 has no concept of alias precedence. When it encounters  on the CLI, it parses it correctly. But it *also* applies the default for  to its own key.  then attempts to propagate values between aliases, but since both  (provided via CLI) and  (provided via default) exist, it skips overriding the primary key.

## Solution
Stop passing  definitions down to . Instead, we parse everything without defaults, let alias propagation resolve CLI overrides across different naming conventions, and then manually apply defaults at the very end to any keys (and their aliases) that are still . Added a test covering this case.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Restored proper default value propagation after alias resolution, ensuring both primary options and their aliases receive specified defaults when not explicitly provided
  * Fixed issue where kebab-case CLI arguments were not correctly overriding camelCase default values

* **Tests**
  * Added test case verifying that kebab-case command-line arguments properly override camelCase default values as expected

<!-- end of auto-generated comment: release notes by coderabbit.ai -->