### PR TITLE
feat: support subcommand aliases

### DIFF
--- a/src/command.ts
+++ b/src/command.ts
@@ -1,6 +1,6 @@
 import { camelCase } from "scule";
-import type { CommandContext, CommandDef, ArgsDef } from "./types.ts";
-import { CLIError, resolveValue } from "./_utils.ts";
+import type { CommandContext, CommandDef, ArgsDef, SubCommandsDef } from "./types.ts";
+import { CLIError, resolveValue, toArray } from "./_utils.ts";
 import { parseArgs } from "./args.ts";
 import { cyan } from "./_color.ts";
 
@@ -43,15 +43,13 @@ export async function runCommand<T extends ArgsDef = ArgsDef>(
       const subCommandArgIndex = findSubCommandIndex(opts.rawArgs, cmdArgs);
       const subCommandName = opts.rawArgs[subCommandArgIndex];
       if (subCommandName) {
-        if (!subCommands[subCommandName]) {
+        const subCommand = await _findSubCommand(subCommands, subCommandName);
+        if (!subCommand) {
           throw new CLIError(`Unknown command ${cyan(subCommandName)}`, "E_UNKNOWN_COMMAND");
         }
-        const subCommand = await resolveValue(subCommands[subCommandName]);
-        if (subCommand) {
-          await runCommand(subCommand, {
-            rawArgs: opts.rawArgs.slice(subCommandArgIndex + 1),
-          });
-        }
+        await runCommand(subCommand, {
+          rawArgs: opts.rawArgs.slice(subCommandArgIndex + 1),
+        });
       } else if (!cmd.run) {
         throw new CLIError(`No command specified.`, "E_NO_COMMAND");
       }
@@ -79,7 +77,7 @@ export async function resolveSubCommand<T extends ArgsDef = ArgsDef>(
     const cmdArgs = await resolveValue(cmd.args || {});
     const subCommandArgIndex = findSubCommandIndex(rawArgs, cmdArgs);
     const subCommandName = rawArgs[subCommandArgIndex]!;
-    const subCommand = await resolveValue(subCommands[subCommandName]);
+    const subCommand = await _findSubCommand(subCommands, subCommandName);
     if (subCommand) {
       return resolveSubCommand(subCommand, rawArgs.slice(subCommandArgIndex + 1), cmd);
     }
@@ -88,6 +86,27 @@ export async function resolveSubCommand<T extends ArgsDef = ArgsDef>(
 }
 
 // --- internal ---
+
+async function _findSubCommand(
+  subCommands: SubCommandsDef,
+  name: string,
+): Promise<CommandDef<any> | undefined> {
+  // Direct key match (fast path — no resolution needed)
+  if (name in subCommands) {
+    return resolveValue(subCommands[name]);
+  }
+  // Alias lookup (resolves subcommands to check meta.alias)
+  for (const sub of Object.values(subCommands)) {
+    const resolved = await resolveValue(sub);
+    const meta = await resolveValue(resolved?.meta);
+    if (meta?.alias) {
+      const aliases = toArray(meta.alias);
+      if (aliases.includes(name)) {
+        return resolved;
+      }
+    }
+  }
+}
 
 function findSubCommandIndex(rawArgs: string[], argsDef: ArgsDef): number {
   for (let i = 0; i < rawArgs.length; i++) {

--- a/src/types.ts
+++ b/src/types.ts
@@ -89,6 +89,7 @@ export interface CommandMeta {
   version?: string;
   description?: string;
   hidden?: boolean;
+  alias?: string | string[];
 }
 
 // Command: Definition

--- a/src/usage.ts
+++ b/src/usage.ts
@@ -1,5 +1,5 @@
 import * as colors from "./_color.ts";
-import { formatLineColumns, resolveValue } from "./_utils.ts";
+import { formatLineColumns, resolveValue, toArray } from "./_utils.ts";
 import type { ArgsDef, CommandDef } from "./types.ts";
 import { resolveArgs } from "./args.ts";
 
@@ -93,8 +93,10 @@ export async function renderUsage<T extends ArgsDef = ArgsDef>(
       if (meta?.hidden) {
         continue;
       }
-      commandsLines.push([colors.cyan(name), meta?.description || ""]);
-      commandNames.push(name);
+      const aliases = toArray(meta?.alias);
+      const label = [name, ...aliases].join(", ");
+      commandsLines.push([colors.cyan(label), meta?.description || ""]);
+      commandNames.push(name, ...aliases);
     }
     usageLine.push(commandNames.join("|"));
   }

--- a/test/main.test.ts
+++ b/test/main.test.ts
@@ -143,6 +143,129 @@ describe("sub command", () => {
   });
 });
 
+describe("sub command aliases", () => {
+  it("resolves subcommand by single alias", async () => {
+    const runMock = vi.fn();
+
+    const command = defineCommand({
+      subCommands: {
+        install: {
+          meta: { alias: "i" },
+          run: async () => {
+            runMock();
+          },
+        },
+      },
+    });
+
+    await runMain(command, { rawArgs: ["i"] });
+
+    expect(runMock).toHaveBeenCalledOnce();
+  });
+
+  it("resolves subcommand by array of aliases", async () => {
+    const runMock = vi.fn();
+
+    const command = defineCommand({
+      subCommands: {
+        install: {
+          meta: { alias: ["i", "add"] },
+          run: async () => {
+            runMock();
+          },
+        },
+      },
+    });
+
+    await runMain(command, { rawArgs: ["add"] });
+
+    expect(runMock).toHaveBeenCalledOnce();
+  });
+
+  it("resolves nested subcommand aliases", async () => {
+    const runMock = vi.fn();
+
+    const command = defineCommand({
+      subCommands: {
+        workspace: {
+          meta: { alias: "ws" },
+          subCommands: {
+            list: {
+              meta: { alias: "ls" },
+              run: async () => {
+                runMock();
+              },
+            },
+          },
+        },
+      },
+    });
+
+    await runMain(command, { rawArgs: ["ws", "ls"] });
+
+    expect(runMock).toHaveBeenCalledOnce();
+  });
+
+  it("prefers direct key match over alias", async () => {
+    const directMock = vi.fn();
+    const aliasMock = vi.fn();
+
+    const command = defineCommand({
+      subCommands: {
+        i: {
+          run: async () => {
+            directMock();
+          },
+        },
+        install: {
+          meta: { alias: "i" },
+          run: async () => {
+            aliasMock();
+          },
+        },
+      },
+    });
+
+    await runMain(command, { rawArgs: ["i"] });
+
+    expect(directMock).toHaveBeenCalledOnce();
+    expect(aliasMock).not.toHaveBeenCalled();
+  });
+
+  it("throws for unknown command even with aliases defined", async () => {
+    const command = defineCommand({
+      subCommands: {
+        install: {
+          meta: { alias: "i" },
+          run: async () => {},
+        },
+      },
+    });
+
+    await expect(commandModule.runCommand(command, { rawArgs: ["unknown"] })).rejects.toThrow(
+      "Unknown command",
+    );
+  });
+
+  it("shows aliases in usage output", async () => {
+    const command = defineCommand({
+      meta: { name: "cli", description: "Test CLI" },
+      subCommands: {
+        install: {
+          meta: { name: "install", alias: ["i", "add"], description: "Install packages" },
+        },
+        build: {
+          meta: { name: "build", alias: "b", description: "Build project" },
+        },
+      },
+    });
+
+    const usage = await renderUsage(command);
+    expect(usage).toContain("install, i, add");
+    expect(usage).toContain("build, b");
+  });
+});
+
 describe("sub command with parent args", () => {
   it("resolves subcommand when parent has string arg", async () => {
     const runMock = vi.fn();


### PR DESCRIPTION
## Summary

Adds support for defining aliases on subcommands via `CommandMeta.alias`, resolving #152.

```ts
defineCommand({
  subCommands: {
    install: {
      meta: { alias: ["i", "add"] },
      run: () => { /* ... */ },
    },
  },
})
```

- `alias` field accepts `string | string[]` on `CommandMeta`
- Direct subcommand key matches take priority over alias lookups
- Aliases are displayed in `--help` output (e.g. `install, i, add`)
- Works with nested subcommands

Consolidates work from #155, #170, and #224 — all three original authors are credited.

### Lazy loading

Alias resolution is designed to minimize unnecessary subcommand loading:

- **Direct key match (fast path):** `name in subCommands` is a plain property check — no subcommand is resolved or imported.
- **Alias fallback:** Only reached when the direct key doesn't match. Subcommands are resolved one-by-one and iteration stops at the first alias hit, so dynamic imports (`() => import("./cmd.ts")`) are only triggered as needed.
- **Worst case:** An unknown command resolves all subcommands before erroring — acceptable since it's already an error path.

Hoisting aliases into a separate top-level map was considered but rejected to keep the DX simple (single source of truth in `meta`).

## Test plan

- [x] Single alias resolution (`i` → `install`)
- [x] Array alias resolution (`add` → `install`)
- [x] Nested alias resolution (`ws ls` → `workspace list`)
- [x] Direct key match takes priority over alias
- [x] Unknown command still throws `E_UNKNOWN_COMMAND`
- [x] Aliases appear in usage/help output
- [x] Full test suite passes (76/76)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: 苏向夜 <67710306+fu050409@users.noreply.github.com>
Co-Authored-By: Horu <HigherOrderLogic@users.noreply.github.com>
Co-Authored-By: TJ <ratiofu@users.noreply.github.com>