### PR TITLE
fix(types): narrow camelCase/kebab-case ParsedArgs accessors (#244)

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -1,3 +1,5 @@
+import type { CamelCase, KebabCase } from "scule";
+
 // ----- Args -----
 
 export type ArgType = "boolean" | "string" | "enum" | "positional" | undefined;
@@ -76,6 +78,8 @@ type ParsedArg<T extends ArgDef> =
 // prettier-ignore
 export type ParsedArgs<T extends ArgsDef = ArgsDef> = RawArgs &
   { [K in keyof T]: ParsedArg<T[K]>; } &
+  { [K in keyof T as CamelCase<K & string>]: ParsedArg<T[K]>; } &
+  { [K in keyof T as KebabCase<K & string>]: ParsedArg<T[K]>; } &
   { [K in keyof T as T[K] extends { alias: string } ? T[K]["alias"] : never]: ParsedArg<T[K]> } &
   { [K in keyof T as T[K] extends { alias: string[] } ? T[K]["alias"][number] : never]: ParsedArg<T[K]> } &
   Record<string, string | number | boolean | string[]>;

--- a/test/args-camelcase-types.test-d.ts
+++ b/test/args-camelcase-types.test-d.ts
@@ -1,0 +1,25 @@
+import { describe, it, expectTypeOf } from "vitest";
+import { parseArgs } from "../src/args.ts";
+import type { ArgsDef, ParsedArgs } from "../src/types.ts";
+
+describe("ParsedArgs camelCase/kebab-case key types", () => {
+  it("camelCased accessor of a kebab-cased string arg narrows to string", () => {
+    type Args = {
+      "output-dir": { type: "string"; required: true };
+    };
+    type P = ParsedArgs<Args>;
+
+    expectTypeOf<P["outputDir"]>().toEqualTypeOf<string>();
+    expectTypeOf<P["output-dir"]>().toEqualTypeOf<string>();
+  });
+
+  it("kebab-cased accessor of a camelCased boolean arg narrows to boolean", () => {
+    type Args = {
+      outputDir: { type: "boolean"; default: true };
+    };
+    type P = ParsedArgs<Args>;
+
+    expectTypeOf<P["outputDir"]>().toEqualTypeOf<boolean>();
+    expectTypeOf<P["output-dir"]>().toEqualTypeOf<boolean>();
+  });
+});


### PR DESCRIPTION
Closes #244.

`ParsedArgs<T>` mapped `keyof T` 1:1, so a kebab-cased arg like `output-dir` was only typed at `parsed["output-dir"]`. The camelCased accessor `parsed.outputDir` fell through to the catch-all `Record<string, string | number | boolean | string[]>` at the end of the intersection, widening every camelCase access in TS consumers.

Mirrors each `keyof T` through scule's `CamelCase` and `KebabCase` type-level transforms so both spellings narrow to the declared `ParsedArg<T[K]>` shape.

Regression test in `test/args-camelcase-types.test-d.ts` covers a kebab-declared string arg and a camel-declared boolean arg; pre-fix both fail with "Actual: boolean | string | number | string[]" (the catch-all), post-fix both narrow to the declared type. Full test suite + existing type checks pass.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Tightened TypeScript typings so command-line argument accessors in camelCase or kebab-case consistently resolve to their declared types instead of a broader fallback.

* **Tests**
  * Added type-level regression tests to ensure accessor normalization between camelCase and kebab-case remains correct.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/unjs/citty/pull/246)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->