### PR TITLE
feat: fallback to package.json version for --version flag

### DIFF
--- a/src/_pkg.ts
+++ b/src/_pkg.ts
@@ -1,0 +1,37 @@
+import { existsSync, readFileSync } from "node:fs";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+export function readPackageVersion(startDir?: string): string | undefined {
+  let currentDir = startDir || process.cwd();
+
+  while (true) {
+    const packageJsonPath = join(currentDir, "package.json");
+    if (existsSync(packageJsonPath)) {
+      try {
+        const pkg = JSON.parse(readFileSync(packageJsonPath, "utf8")) as {
+          version?: string;
+        };
+        if (typeof pkg.version === "string" && pkg.version.length > 0) {
+          return pkg.version;
+        }
+      } catch {
+        // ignore invalid package.json
+      }
+    }
+
+    const parentDir = resolve(currentDir, "..");
+    if (parentDir === currentDir) {
+      return undefined;
+    }
+    currentDir = parentDir;
+  }
+}
+
+export function readPackageVersionFromModule(moduleUrl: string): string | undefined {
+  try {
+    return readPackageVersion(dirname(fileURLToPath(moduleUrl)));
+  } catch {
+    return undefined;
+  }
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,6 +1,7 @@
 import type { ArgsDef, CommandDef } from "./types.ts";
 import { resolveSubCommand, runCommand } from "./command.ts";
 import { CLIError, resolveValue, toArray } from "./_utils.ts";
+import { readPackageVersion } from "./_pkg.ts";
 import { showUsage as _showUsage } from "./usage.ts";
 
 export interface RunMainOptions {
@@ -21,10 +22,11 @@ export async function runMain<T extends ArgsDef = ArgsDef>(
       process.exit(0);
     } else if (rawArgs.length === 1 && builtinFlags.version.includes(rawArgs[0]!)) {
       const meta = typeof cmd.meta === "function" ? await cmd.meta() : await cmd.meta;
-      if (!meta?.version) {
+      const version = meta?.version || readPackageVersion();
+      if (!version) {
         throw new CLIError("No version specified", "E_NO_VERSION");
       }
-      console.log(meta.version);
+      console.log(version);
     } else {
       await runCommand(cmd, { rawArgs });
     }

--- a/test/main.test.ts
+++ b/test/main.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi, afterAll } from "vitest";
 import { createMain, defineCommand, renderUsage, runMain, showUsage } from "../src/index.ts";
 import * as commandModule from "../src/command.ts";
+import * as pkgModule from "../src/_pkg.ts";
 
 describe("runMain", () => {
   vi.spyOn(process, "exit").mockImplementation(() => 0 as never);
@@ -36,6 +37,22 @@ describe("runMain", () => {
     expect(consoleMock).toHaveBeenCalledWith("1.0.0");
   });
 
+  it("shows version from package.json when meta version is missing", async () => {
+    const command = defineCommand({
+      meta: {
+        name: "test",
+        description: "Test command",
+      },
+    });
+
+    const readVersionSpy = vi.spyOn(pkgModule, "readPackageVersion").mockReturnValue("3.2.1");
+
+    await runMain(command, { rawArgs: ["--version"] });
+
+    expect(consoleMock).toHaveBeenCalledWith("3.2.1");
+    readVersionSpy.mockRestore();
+  });
+
   it("shows usage with flag `--version` but without version specified", async () => {
     const command = defineCommand({
       meta: {
@@ -44,11 +61,14 @@ describe("runMain", () => {
       },
     });
 
+    const readVersionSpy = vi.spyOn(pkgModule, "readPackageVersion").mockReturnValue(undefined);
+
     await runMain(command, { rawArgs: ["--version"] });
 
     const usage = await renderUsage(command);
     expect(consoleMock).toHaveBeenCalledWith(usage + "\n");
     expect(consoleErrorMock).toHaveBeenCalledWith("No version specified");
+    readVersionSpy.mockRestore();
   });
 
   it.each([["--help"], ["-h"]])("shows usage with flag `%s`", async (flag) => {

--- a/test/pkg.test.ts
+++ b/test/pkg.test.ts
@@ -1,0 +1,44 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { describe, expect, it } from "vitest";
+import { readPackageVersion } from "../src/_pkg.ts";
+
+describe("readPackageVersion", () => {
+  it("reads version from nearest package.json", () => {
+    const dir = mkdtempSync(join(tmpdir(), "citty-pkg-"));
+    try {
+      writeFileSync(
+        join(dir, "package.json"),
+        JSON.stringify({ name: "test-cli", version: "2.3.4" }),
+      );
+      expect(readPackageVersion(dir)).toBe("2.3.4");
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("walks up directories to find package.json", () => {
+    const root = mkdtempSync(join(tmpdir(), "citty-pkg-root-"));
+    const nested = join(root, "nested");
+    try {
+      mkdirSync(nested, { recursive: true });
+      writeFileSync(
+        join(root, "package.json"),
+        JSON.stringify({ name: "test-cli", version: "9.8.7" }),
+      );
+      expect(readPackageVersion(nested)).toBe("9.8.7");
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it("returns undefined when no package.json is found", () => {
+    const dir = mkdtempSync(join(tmpdir(), "citty-pkg-empty-"));
+    try {
+      expect(readPackageVersion(dir)).toBeUndefined();
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});


### PR DESCRIPTION
## Summary

- When `meta.version` is not provided, `--version` / `-v` now reads the nearest `package.json` version from the current working directory
- Keeps existing behavior when `meta.version` is explicitly set
- Still throws `E_NO_VERSION` when neither meta nor package.json provides a version

Fixes #200

## Test plan

- [x] Added unit tests for `readPackageVersion()` (direct lookup, parent walk, not found)
- [x] Added integration test for `--version` fallback via package.json
- [x] Updated existing test to mock missing package.json version
- [x] `pnpm test` passes (114 tests)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Version command now automatically discovers version information from package.json when not explicitly configured, providing a fallback mechanism for version display.
  * Improved version resolution reliability with automatic upward directory search for package metadata.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/unjs/citty/pull/250?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->