### PR TITLE
fix(parser): handle short alias with =value syntax

### DIFF
--- a/src/_parser.ts
+++ b/src/_parser.ts
@@ -131,9 +131,7 @@ export function parseRawArgs<T = Record<string, any>>(
       const name = arg.slice(0, eqIndex);
       const value = arg.slice(eqIndex + 1);
       processedArgs.push(name);
-      if (value !== "") {
-        processedArgs.push(value);
-      }
+      processedArgs.push(value);
       continue;
     }
 

--- a/src/_parser.ts
+++ b/src/_parser.ts
@@ -109,7 +109,7 @@ export function parseRawArgs<T = Record<string, any>>(
   const negatedFlags: Record<string, boolean> = {};
 
   for (let i = 0; i < args.length; i++) {
-    const arg = args[i]!;
+    let arg = args[i]!;
 
     if (arg === "--") {
       // Pass through -- and everything after
@@ -118,9 +118,22 @@ export function parseRawArgs<T = Record<string, any>>(
     }
 
     // Handle --no-flag syntax
-    if (arg.startsWith("--no-")) {
+    if (arg.startsWith("--no-") && !arg.includes("=")) {
       const flagName = arg.slice(5);
       negatedFlags[flagName] = true;
+      continue;
+    }
+
+    // Handle short alias with =value syntax (e.g., -o=bar)
+    // This is needed because node:util parseArgs doesn't handle = for short aliases
+    if (arg.startsWith("-") && !arg.startsWith("--") && arg.includes("=")) {
+      const eqIndex = arg.indexOf("=");
+      const name = arg.slice(0, eqIndex);
+      const value = arg.slice(eqIndex + 1);
+      processedArgs.push(name);
+      if (value !== "") {
+        processedArgs.push(value);
+      }
       continue;
     }
 

--- a/test/parser.test.ts
+++ b/test/parser.test.ts
@@ -26,7 +26,7 @@ describe("parseRawArgs", () => {
     });
   });
 
-  it.fails("handles -<arg>=<value> with alias (#237)", () => {
+  it("handles -<arg>=<value> with alias (#237)", () => {
     const result = parseRawArgs(["-n=John"], {
       string: ["name"],
       alias: {

--- a/test/parser.test.ts
+++ b/test/parser.test.ts
@@ -41,6 +41,21 @@ describe("parseRawArgs", () => {
     });
   });
 
+  it("handles -<arg>= with empty value", () => {
+    const result = parseRawArgs(["-n="], {
+      string: ["name"],
+      alias: {
+        n: ["name"],
+      },
+    });
+
+    expect(result).toEqual({
+      _: [],
+      n: "",
+      name: "",
+    });
+  });
+
   it("handles default values", () => {
     const result = parseRawArgs([], { default: { name: "Default" } });
 


### PR DESCRIPTION
## Problem

When using short aliases with `=value` syntax like `-n=John`, the native `node:util.parseArgs` does not handle `=` for short aliases, causing the `=` to be included in the parsed value.

## Changes

Added preprocessing in `_parser.ts` to detect `-<alias>=<value>` patterns and split them into `-<alias> <value>` before passing to `node:util.parseArgs`. Long-form `--option=value` is already handled natively.

Also removed `.fails` from the existing test that was marking this as a known broken test, since the fix now makes it pass.

## Closes

Closes #237


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of negated flag syntax (`--no-<flag>`) so it's ignored when given with `=` and applied correctly otherwise.
  * Fixed parsing of short-flag value syntax (e.g., `-o=value`) so short aliases accept `=` assignments.
  * Treats explicitly empty values (like `-x=`) as empty strings rather than errors.

* **Tests**
  * Added/updated tests to cover `-o=value` and empty-value parsing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->