### PR TITLE
fix(command): skip parent run() when a sub command has run

### DIFF
--- a/src/command.ts
+++ b/src/command.ts
@@ -48,6 +48,7 @@ export async function runCommand<T extends ArgsDef = ArgsDef>(
     }
 
     // Handle sub command
+    let ranSubCommand = false;
     const subCommands = await resolveValue(cmd.subCommands);
     if (subCommands && Object.keys(subCommands).length > 0) {
       const subCommandArgIndex = findSubCommandIndex(opts.rawArgs, cmdArgs);
@@ -61,6 +62,7 @@ export async function runCommand<T extends ArgsDef = ArgsDef>(
         await runCommand(subCommand, {
           rawArgs: opts.rawArgs.slice(subCommandArgIndex + 1),
         });
+        ranSubCommand = true;
       } else {
         // No explicit sub command — check for default
         const defaultSubCommand = await resolveValue(cmd.default);
@@ -81,14 +83,15 @@ export async function runCommand<T extends ArgsDef = ArgsDef>(
           await runCommand(subCommand, {
             rawArgs: opts.rawArgs,
           });
+          ranSubCommand = true;
         } else if (!cmd.run) {
           throw new CLIError(`No command specified.`, "E_NO_COMMAND");
         }
       }
     }
 
-    // Handle main command
-    if (typeof cmd.run === "function") {
+    // Handle main command (skipped when a sub command already ran)
+    if (!ranSubCommand && typeof cmd.run === "function") {
       result = await cmd.run(context);
     }
   } catch (error) {

--- a/test/main.test.ts
+++ b/test/main.test.ts
@@ -141,6 +141,45 @@ describe("sub command", () => {
     expect(cleanupMock).toHaveBeenCalledOnce();
     expect(cleanupMock).toHaveBeenCalledWith("bar");
   });
+
+  // https://github.com/unjs/citty/issues/253
+  it("does not run the parent's run() after a sub command runs", async () => {
+    const mainRunMock = vi.fn();
+    const subRunMock = vi.fn();
+
+    const command = defineCommand({
+      run: mainRunMock,
+      subCommands: {
+        test: {
+          run: subRunMock,
+        },
+      },
+    });
+
+    await runMain(command, { rawArgs: ["test"] });
+
+    expect(subRunMock).toHaveBeenCalledOnce();
+    expect(mainRunMock).not.toHaveBeenCalled();
+  });
+
+  it("runs the parent's run() when no sub command is given", async () => {
+    const mainRunMock = vi.fn();
+    const subRunMock = vi.fn();
+
+    const command = defineCommand({
+      run: mainRunMock,
+      subCommands: {
+        test: {
+          run: subRunMock,
+        },
+      },
+    });
+
+    await runMain(command, { rawArgs: [] });
+
+    expect(mainRunMock).toHaveBeenCalledOnce();
+    expect(subRunMock).not.toHaveBeenCalled();
+  });
 });
 
 describe("sub command aliases", () => {


### PR DESCRIPTION
Fixes #253

### Problem

`runCommand` dispatches an explicit (or default) sub command and then falls through to the "Handle main command" block, so the parent's `run()` executes right after the sub command's:

```js
const main = defineCommand({
  run() { console.log("main"); },
  subCommands: { test: { run() { console.log("test"); } } },
});
runMain(main); // `cli test` prints "test" then "main"
```

The documented lifecycle is `setup()` → resolve subcommand **or** `run()` → `cleanup()` (AGENTS.md), and the `E_DEFAULT_CONFLICT` guard already shows only one action is meant to execute per invocation. The fall-through has been there since the file was created; the existing sub-command test never caught it because its parent command has no `run`.

### Fix

Track whether a sub command was dispatched and skip the parent `run()` in that case. Parent `setup()`/`cleanup()` still wrap the sub command run, and a parent with `run` and no matching sub command arg behaves as before.

### Tests

`does not run the parent's run() after a sub command runs` fails on `main` (parent run was called) and passes with this change; a second case pins that the parent's `run()` still executes when no sub command is given. Full `pnpm test`: lint 0 warnings / 0 errors, 111 tests passed, types clean.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed command execution flow where the parent command was incorrectly running after a subcommand executed
  * Improved conditional handling of the main command path when subcommands are present

* **Tests**
  * Added test coverage validating correct command execution behavior when subcommands are and aren't provided

<!-- end of auto-generated comment: release notes by coderabbit.ai -->