### PR TITLE
fix(args): enforce required check for enum arguments

### DIFF
--- a/src/args.ts
+++ b/src/args.ts
@@ -75,6 +75,9 @@ export function parseArgs<T extends ArgsDef = ArgsDef>(
     } else if (arg.type === "enum") {
       const argument = parsedArgsProxy[arg.name];
       const options = arg.options || [];
+      if (arg.required && argument === undefined) {
+        throw new CLIError(`Missing required argument: --${arg.name}`, "EARG");
+      }
       if (argument !== undefined && options.length > 0 && !options.includes(argument)) {
         throw new CLIError(
           `Invalid value for argument: ${cyan(`--${arg.name}`)} (${cyan(argument)}). Expected one of: ${options.map((o) => cyan(o)).join(", ")}.`,

--- a/test/args.test.ts
+++ b/test/args.test.ts
@@ -73,6 +73,11 @@ describe("args", () => {
       { value: { type: "enum", options: ["one", "two"] } },
       "Invalid value for argument: --value (three). Expected one of: one, two.",
     ],
+    [
+      [],
+      { value: { type: "enum", options: ["one", "two"], required: true } },
+      "Missing required argument: --value",
+    ],
   ])("should throw error with %o (%o)", (rawArgs, definition, result) => {
     // TODO: should check for exact match
     // https://github.com/vitest-dev/vitest/discussions/6048


### PR DESCRIPTION
A `required` enum arg is silently allowed to be missing, while `string`, `boolean` and `positional` all throw on the same input.

The per-arg validation in `parseArgs` is an if/else-if chain. The `enum` branch only checks that a provided value is one of `options`, so the trailing `else if (arg.required && … === undefined)` that enforces presence is never reached for enum args:

```ts
} else if (arg.type === "enum") {
  // ...only validates options membership
} else if (arg.required && parsedArgsProxy[arg.name] === undefined) {
  throw new CLIError(`Missing required argument: --${arg.name}`, "EARG");
}
```

So `parseArgs([], { mode: { type: "enum", options: ["a", "b"], required: true } })` resolves to `{ mode: undefined }` instead of throwing. Also reproduces on the published 0.2.2.

The fix adds the same presence check inside the enum branch, before the options validation, reusing the existing error. Non-required enums and already-provided values are unchanged.

Added a case to the existing throw-error table, next to the required string/positional ones.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation for required enum arguments in the CLI.
  * Missing required enum values now return a clear error instead of being accepted until later parsing steps.
  * Updated error handling to better match the expected message when a required enum option is not provided.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->