### PR TITLE
feat(args): support a `multiple` modifier for arguments

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,13 +164,14 @@ Plugin `setup` hooks run before the command's `setup` (in order), `cleanup` hook
 
 ### Common Options
 
-| Option        | Description                                                   |
-| ------------- | ------------------------------------------------------------- |
-| `description` | Help text shown in usage output                               |
-| `required`    | Whether the argument is required                              |
-| `default`     | Default value when not provided                               |
-| `alias`       | Short aliases (e.g., `["f"]`). Not for `positional`           |
-| `valueHint`   | Display hint in help (e.g., `"host"` renders `--name=<host>`) |
+| Option        | Description                                                          |
+| ------------- | -------------------------------------------------------------------- |
+| `description` | Help text shown in usage output                                      |
+| `required`    | Whether the argument is required                                     |
+| `multiple`    | Collect repeated values into an array (`string`/`enum`/`positional`) |
+| `default`     | Default value when not provided                                      |
+| `alias`       | Short aliases (e.g., `["f"]`). Not for `positional`                  |
+| `valueHint`   | Display hint in help (e.g., `"host"` renders `--name=<host>`)        |
 
 ### Example
 
@@ -189,6 +190,43 @@ const main = defineCommand({
   },
   run({ args }) {
     console.log(`${args.greeting} ${args.name}! (level: ${args.level})`);
+  },
+});
+```
+
+### Multiple Values
+
+Set `multiple: true` to collect repeated values into an array. It works with `string`, `enum`, and `positional` arguments. Combined with `required`, it expresses the full cardinality matrix (both default to `false`):
+
+| `required` | `multiple` | Cardinality  | Parsed type             |
+| ---------- | ---------- | ------------ | ----------------------- |
+| `false`    | `false`    | zero or one  | `T \| undefined`        |
+| `true`     | `false`    | exactly one  | `T`                     |
+| `false`    | `true`     | zero or more | `T[]` (`[]` when empty) |
+| `true`     | `true`     | one or more  | `T[]` (must have ≥ 1)   |
+
+A repeated flag collects each occurrence, and a `multiple` positional is variadic — it greedily consumes the remaining positional tokens. Only the last positional may be `multiple`.
+
+```js
+const main = defineCommand({
+  args: {
+    // Repeatable flag: `--env A=1 --env B=2` → ["A=1", "B=2"]
+    env: {
+      type: "string",
+      description: "Environment variable as NAME=VALUE (repeatable)",
+      multiple: true,
+    },
+    // Variadic positional: `lint a.ts b.ts` → ["a.ts", "b.ts"]
+    files: {
+      type: "positional",
+      description: "Files to lint",
+      required: true,
+      multiple: true,
+    },
+  },
+  run({ args }) {
+    console.log(args.env); // string[]
+    console.log(args.files); // string[]
   },
 });
 ```

--- a/src/_parser.ts
+++ b/src/_parser.ts
@@ -56,25 +56,24 @@ export function parseRawArgs<T = Record<string, any>>(
     }
   > = {};
 
-  // Helper to get option type
-  function getType(name: string): "boolean" | "string" {
-    if (booleans.has(name)) return "boolean";
-    // Check aliases
+  // Check if a name, or any of its aliases, belongs to the given option set
+  function isInSet(name: string, set: Set<string>): boolean {
+    if (set.has(name)) return true;
     const aliases = mainToAliases.get(name) || [];
     for (const alias of aliases) {
-      if (booleans.has(alias)) return "boolean";
+      if (set.has(alias)) return true;
     }
-    return "string";
+    return false;
+  }
+
+  // Helper to get option type
+  function getType(name: string): "boolean" | "string" {
+    return isInSet(name, booleans) ? "boolean" : "string";
   }
 
   // Check if a name is a known string option (directly or via alias)
   function isStringType(name: string): boolean {
-    if (strings.has(name)) return true;
-    const aliases = mainToAliases.get(name) || [];
-    for (const alias of aliases) {
-      if (strings.has(alias)) return true;
-    }
-    return false;
+    return isInSet(name, strings);
   }
 
   // Collect all option names
@@ -147,16 +146,21 @@ export function parseRawArgs<T = Record<string, any>>(
   // Add positionals
   out._ = parsed.positionals;
 
-  // Add parsed values
-  for (const [key, value] of Object.entries(parsed.values)) {
-    let coerced = value;
+  // Coerce a single raw value to its declared type
+  function coerceValue(key: string, value: any): any {
     const type = getType(key);
     if (type === "boolean" && typeof value === "string") {
-      coerced = value !== "false";
-    } else if (isStringType(key) && typeof value === "boolean") {
-      coerced = "";
+      return value !== "false";
     }
-    (out as any)[key] = coerced;
+    if (isStringType(key) && typeof value === "boolean") {
+      return "";
+    }
+    return value;
+  }
+
+  // Add parsed values
+  for (const [key, value] of Object.entries(parsed.values)) {
+    (out as any)[key] = coerceValue(key, value);
   }
 
   // Apply negated flags (with alias resolution)

--- a/src/_parser.ts
+++ b/src/_parser.ts
@@ -3,6 +3,7 @@ import { parseArgs } from "node:util";
 export interface ParseOptions {
   boolean?: string[];
   string?: string[];
+  multiple?: string[];
   alias?: Record<string, string[]>;
   default?: Record<string, any>;
 }
@@ -17,6 +18,7 @@ export function parseRawArgs<T = Record<string, any>>(
 ): Argv<T> {
   const booleans = new Set(opts.boolean || []);
   const strings = new Set(opts.string || []);
+  const multiples = new Set(opts.multiple || []);
   const aliasMap = opts.alias || {};
   const defaults = opts.default || {};
 
@@ -76,6 +78,11 @@ export function parseRawArgs<T = Record<string, any>>(
     return isInSet(name, strings);
   }
 
+  // Check if a name should collect repeated values (directly or via alias)
+  function isMultiple(name: string): boolean {
+    return isInSet(name, multiples);
+  }
+
   // Collect all option names
   const allOptions = new Set<string>([
     ...booleans,
@@ -92,6 +99,7 @@ export function parseRawArgs<T = Record<string, any>>(
       options[name] = {
         type,
         default: defaults[name],
+        multiple: isMultiple(name),
       };
     }
   }
@@ -148,6 +156,10 @@ export function parseRawArgs<T = Record<string, any>>(
 
   // Coerce a single raw value to its declared type
   function coerceValue(key: string, value: any): any {
+    // A `multiple` option arrives as an array; coerce each item individually
+    if (Array.isArray(value)) {
+      return value.map((item) => coerceValue(key, item));
+    }
     const type = getType(key);
     if (type === "boolean" && typeof value === "string") {
       return value !== "false";

--- a/src/args.ts
+++ b/src/args.ts
@@ -26,6 +26,7 @@ export function parseArgs<T extends ArgsDef = ArgsDef>(
   const parseOptions = {
     boolean: [] as string[],
     string: [] as string[],
+    multiple: [] as string[],
     alias: {} as Record<string, string[]>,
     default: {} as Record<string, boolean | string>,
   } satisfies ParseOptions;
@@ -41,7 +42,10 @@ export function parseArgs<T extends ArgsDef = ArgsDef>(
     } else if (arg.type === "boolean") {
       parseOptions.boolean.push(arg.name);
     }
-    if (arg.default !== undefined) {
+    if (arg.multiple) {
+      parseOptions.multiple.push(arg.name);
+    }
+    if (arg.default !== undefined && !arg.multiple) {
       parseOptions.default[arg.name] = arg.default;
     }
     if (arg.alias) {
@@ -87,6 +91,15 @@ export function parseArgs<T extends ArgsDef = ArgsDef>(
       } else {
         parsedArgsProxy[arg.name] = arg.default;
       }
+    } else if (arg.multiple) {
+      const values: string[] = parsedArgsProxy[arg.name] ?? [];
+      for (const value of values) {
+        assertEnumValue(arg, value);
+      }
+      if (arg.required && values.length === 0) {
+        throw new CLIError(`Missing required argument: --${arg.name}`, "EARG");
+      }
+      parsedArgsProxy[arg.name] = values;
     } else if (arg.type === "enum") {
       assertEnumValue(arg, parsedArgsProxy[arg.name]);
     } else if (arg.required && parsedArgsProxy[arg.name] === undefined) {

--- a/src/args.ts
+++ b/src/args.ts
@@ -33,6 +33,17 @@ export function parseArgs<T extends ArgsDef = ArgsDef>(
 
   const args = resolveArgs(argsDef);
 
+  const positionals = args.filter(({ type }) => type === "positional");
+
+  for (const [index, positional] of positionals.entries()) {
+    if (positional.multiple && index < positionals.length - 1) {
+      throw new CLIError(
+        `A "multiple" positional argument must be the last positional argument, but "${positional.name}" is not.`,
+        "EARG",
+      );
+    }
+  }
+
   for (const arg of args) {
     if (arg.type === "positional") {
       continue;
@@ -79,7 +90,15 @@ export function parseArgs<T extends ArgsDef = ArgsDef>(
   });
 
   for (const [, arg] of args.entries()) {
-    if (arg.type === "positional") {
+    if (arg.type === "positional" && arg.multiple) {
+      if (positionalArguments.length === 0 && arg.required !== false) {
+        throw new CLIError(
+          `Missing required positional argument: ${arg.name.toUpperCase()}`,
+          "EARG",
+        );
+      }
+      parsedArgsProxy[arg.name] = positionalArguments;
+    } else if (arg.type === "positional") {
       const nextPositionalArgument = positionalArguments.shift();
       if (nextPositionalArgument !== undefined) {
         parsedArgsProxy[arg.name] = nextPositionalArgument;

--- a/src/args.ts
+++ b/src/args.ts
@@ -4,6 +4,21 @@ import type { Arg, ArgsDef, ParsedArgs } from "./types.ts";
 import { CLIError, toArray } from "./_utils.ts";
 import { cyan } from "./_color.ts";
 
+// Throw if an enum arg received a value outside its declared options. No-op for
+// non-enum args and for an absent value.
+function assertEnumValue(arg: Arg, value: unknown): void {
+  if (arg.type !== "enum" || value === undefined) {
+    return;
+  }
+  const options = arg.options || [];
+  if (options.length > 0 && !options.includes(value as string)) {
+    throw new CLIError(
+      `Invalid value for argument: ${cyan(`--${arg.name}`)} (${cyan(value as string)}). Expected one of: ${options.map((o) => cyan(o)).join(", ")}.`,
+      "EARG",
+    );
+  }
+}
+
 export function parseArgs<T extends ArgsDef = ArgsDef>(
   rawArgs: string[],
   argsDef: ArgsDef,
@@ -73,14 +88,7 @@ export function parseArgs<T extends ArgsDef = ArgsDef>(
         parsedArgsProxy[arg.name] = arg.default;
       }
     } else if (arg.type === "enum") {
-      const argument = parsedArgsProxy[arg.name];
-      const options = arg.options || [];
-      if (argument !== undefined && options.length > 0 && !options.includes(argument)) {
-        throw new CLIError(
-          `Invalid value for argument: ${cyan(`--${arg.name}`)} (${cyan(argument)}). Expected one of: ${options.map((o) => cyan(o)).join(", ")}.`,
-          "EARG",
-        );
-      }
+      assertEnumValue(arg, parsedArgsProxy[arg.name]);
     } else if (arg.required && parsedArgsProxy[arg.name] === undefined) {
       throw new CLIError(`Missing required argument: --${arg.name}`, "EARG");
     }

--- a/src/types.ts
+++ b/src/types.ts
@@ -11,10 +11,11 @@ export type _ArgDef<T extends ArgType, VT extends boolean | number | string> = {
   alias?: string | string[];
   default?: VT;
   required?: boolean;
+  multiple?: boolean;
   options?: string[];
 };
 
-export type BooleanArgDef = Omit<_ArgDef<"boolean", boolean>, "options"> & {
+export type BooleanArgDef = Omit<_ArgDef<"boolean", boolean>, "options" | "multiple"> & {
   negativeDescription?: string;
 };
 export type StringArgDef = Omit<_ArgDef<"string", string>, "options">;
@@ -25,11 +26,15 @@ export type ArgDef = BooleanArgDef | StringArgDef | PositionalArgDef | EnumArgDe
 
 export type ArgsDef = Record<string, ArgDef>;
 
-export type Arg = ArgDef & { name: string; alias: string[] };
+export type Arg = ArgDef & {
+  name: string;
+  alias: string[];
+  multiple?: boolean;
+};
 
 // Args: Parsed
 
-type ResolveParsedArgType<T extends ArgDef, VT> = T extends {
+type ResolveScalarArgType<T extends ArgDef, VT> = T extends {
   default?: any;
   required?: boolean;
 }
@@ -39,6 +44,10 @@ type ResolveParsedArgType<T extends ArgDef, VT> = T extends {
       ? VT
       : VT | undefined
   : VT | undefined;
+
+type ResolveParsedArgType<T extends ArgDef, VT> = T extends { multiple: true }
+  ? VT[]
+  : ResolveScalarArgType<T, VT>;
 
 type ParsedPositionalArg<T extends ArgDef> = T extends { type: "positional" }
   ? ResolveParsedArgType<T, string>

--- a/src/usage.ts
+++ b/src/usage.ts
@@ -36,7 +36,7 @@ export async function renderUsage<T extends ArgsDef = ArgsDef>(
 
   for (const arg of cmdArgs) {
     if (arg.type === "positional") {
-      const name = arg.name.toUpperCase();
+      const name = arg.name.toUpperCase() + (arg.multiple ? "..." : "");
       const isRequired = arg.required !== false && arg.default === undefined;
       posLines.push([colors.cyan(name + renderValueHint(arg)), renderDescription(arg, isRequired)]);
       usageLine.push(isRequired ? `<${name}>` : `[${name}]`);
@@ -136,16 +136,17 @@ export async function renderUsage<T extends ArgsDef = ArgsDef>(
 function renderValueHint(arg: Arg) {
   const valueHint = arg.valueHint ? `=<${arg.valueHint}>` : "";
   const fallbackValueHint = valueHint || `=<${snakeCase(arg.name)}>`;
+  const repeat = arg.multiple ? "..." : "";
 
   if (!arg.type || arg.type === "positional" || arg.type === "boolean") {
     return valueHint;
   }
 
   if (arg.type === "enum" && arg.options?.length) {
-    return `=<${arg.options.join("|")}>`;
+    return `=<${arg.options.join("|")}>${repeat}`;
   }
 
-  return fallbackValueHint;
+  return fallbackValueHint + repeat;
 }
 
 function renderDescription(arg: Arg, required: boolean) {

--- a/test/args.test.ts
+++ b/test/args.test.ts
@@ -79,6 +79,30 @@ describe("args", () => {
       },
       { level: ["info", "warn"], _: [] },
     ],
+    /**
+     * Multiple (positionals)
+     */
+    // one or more: a variadic positional greedily consumes remaining tokens
+    [
+      ["a.ts", "b.ts"],
+      { files: { type: "positional", multiple: true } },
+      { files: ["a.ts", "b.ts"], _: ["a.ts", "b.ts"] },
+    ],
+    // zero or more: no values parses to an empty array
+    [[], { files: { type: "positional", required: false, multiple: true } }, { files: [], _: [] }],
+    // a leading positional is filled before the trailing variadic one
+    [
+      ["build", "a.ts", "b.ts"],
+      {
+        command: { type: "positional" },
+        files: { type: "positional", multiple: true },
+      },
+      {
+        command: "build",
+        files: ["a.ts", "b.ts"],
+        _: ["build", "a.ts", "b.ts"],
+      },
+    ],
   ] as [string[], ArgsDef, any][])(
     "should parsed correctly %o (%o)",
     (rawArgs, definition, result) => {
@@ -114,12 +138,29 @@ describe("args", () => {
       { level: { type: "enum", options: ["info", "warn"], multiple: true } },
       "Invalid value for argument: --level (trace). Expected one of: info, warn.",
     ],
+    // one or more positional: zero values fails like a missing required argument
+    [
+      [],
+      { files: { type: "positional", multiple: true } },
+      "Missing required positional argument: FILES",
+    ],
   ])("should throw error with %o (%o)", (rawArgs, definition, result) => {
     // TODO: should check for exact match
     // https://github.com/vitest-dev/vitest/discussions/6048
     expect(() => {
       parseArgs(rawArgs, definition);
     }).toThrowError(result);
+  });
+
+  it("should throw when a multiple positional is not the last positional", () => {
+    expect(() => {
+      parseArgs(["a", "b"], {
+        files: { type: "positional", multiple: true },
+        output: { type: "positional" },
+      });
+    }).toThrowError(
+      'A "multiple" positional argument must be the last positional argument, but "files" is not.',
+    );
   });
 
   it("should resolve camelCase argument", () => {

--- a/test/args.test.ts
+++ b/test/args.test.ts
@@ -50,6 +50,35 @@ describe("args", () => {
       { fooBar: { type: "enum", options: ["one", "two"], default: "two" } },
       { fooBar: "one", "foo-bar": "one", _: [] },
     ],
+    /**
+     * Multiple (flags)
+     */
+    // zero or more: repeated values collect into an array
+    [
+      ["--env", "A=1", "--env", "B=2"],
+      { env: { type: "string", multiple: true } },
+      { env: ["A=1", "B=2"], _: [] },
+    ],
+    // zero or more: no values parses to an empty array (not undefined)
+    [[], { env: { type: "string", multiple: true } }, { env: [], _: [] }],
+    // one or more: a single value still collects into an array
+    [
+      ["--env", "A=1"],
+      { env: { type: "string", required: true, multiple: true } },
+      { env: ["A=1"], _: [] },
+    ],
+    // multiple enum: each value collected and validated
+    [
+      ["--level", "info", "--level", "warn"],
+      {
+        level: {
+          type: "enum",
+          options: ["info", "warn", "error"],
+          multiple: true,
+        },
+      },
+      { level: ["info", "warn"], _: [] },
+    ],
   ] as [string[], ArgsDef, any][])(
     "should parsed correctly %o (%o)",
     (rawArgs, definition, result) => {
@@ -72,6 +101,18 @@ describe("args", () => {
       ["--value", "three"],
       { value: { type: "enum", options: ["one", "two"] } },
       "Invalid value for argument: --value (three). Expected one of: one, two.",
+    ],
+    // one or more: zero values fails like a missing required argument
+    [
+      [],
+      { env: { type: "string", required: true, multiple: true } },
+      "Missing required argument: --env",
+    ],
+    // multiple enum: an invalid value is rejected
+    [
+      ["--level", "trace"],
+      { level: { type: "enum", options: ["info", "warn"], multiple: true } },
+      "Invalid value for argument: --level (trace). Expected one of: info, warn.",
     ],
   ])("should throw error with %o (%o)", (rawArgs, definition, result) => {
     // TODO: should check for exact match

--- a/test/parser.test.ts
+++ b/test/parser.test.ts
@@ -178,4 +178,42 @@ describe("parseRawArgs", () => {
     expect(result.nightly).toBe("");
     expect(typeof result.nightly).toBe("string");
   });
+
+  it("collects repeated flags into an array when multiple is set", () => {
+    const result = parseRawArgs(["--env", "A=1", "--env", "B=2"], {
+      string: ["env"],
+      multiple: ["env"],
+    });
+
+    expect(result).toEqual({
+      _: [],
+      env: ["A=1", "B=2"],
+    });
+  });
+
+  it("collects a single occurrence into an array when multiple is set", () => {
+    const result = parseRawArgs(["--env", "A=1"], {
+      string: ["env"],
+      multiple: ["env"],
+    });
+
+    expect(result).toEqual({
+      _: [],
+      env: ["A=1"],
+    });
+  });
+
+  it("collects across an alias and its primary name when multiple is set", () => {
+    const result = parseRawArgs(["-e", "A=1", "--environment", "B=2"], {
+      string: ["environment"],
+      multiple: ["environment"],
+      alias: { environment: ["e"] },
+    });
+
+    expect(result).toEqual({
+      _: [],
+      environment: ["A=1", "B=2"],
+      e: ["A=1", "B=2"],
+    });
+  });
 });

--- a/test/usage.test.ts
+++ b/test/usage.test.ts
@@ -150,6 +150,44 @@ describe("usage", () => {
     `);
   });
 
+  it("marks multiple flags as repeatable and multiple positionals as variadic", async () => {
+    const command = defineCommand({
+      meta: {
+        name: "lint",
+        description: "Lint files",
+      },
+      args: {
+        env: {
+          type: "string",
+          multiple: true,
+          description: "Env vars",
+        },
+        files: {
+          type: "positional",
+          multiple: true,
+          description: "Files",
+        },
+      },
+    });
+
+    const usage = await renderUsage(command);
+
+    expect(usage).toMatchInlineSnapshot(`
+      "Lint files (lint)
+
+      USAGE lint [OPTIONS] <FILES...>
+
+      ARGUMENTS
+
+        FILES...    Files (Required)
+
+      OPTIONS
+
+        --env=<env>...    Env vars
+      "
+    `);
+  });
+
   it("renders subcommands", async () => {
     const command = defineCommand({
       meta: {


### PR DESCRIPTION
Closes #258.

Adds an optional `multiple?: boolean` modifier to argument definitions. Combined with the existing `required?: boolean`, it covers the full cardinality matrix (both default to `false`, so the change is additive and non-breaking). It applies to `string`, `enum`, and `positional` args: repeated flags collect into an array and a `multiple` positional is variadic. Type inference flips to `T[]` accordingly, and usage output marks the repeatability.

See #258 for the full rationale, cardinality matrix, and examples.
