### PR TITLE
feat: validator in args

### DIFF
--- a/src/args.ts
+++ b/src/args.ts
@@ -84,6 +84,16 @@ export function parseArgs<T extends ArgsDef = ArgsDef>(
     } else if (arg.required && parsedArgsProxy[arg.name] === undefined) {
       throw new CLIError(`Missing required argument: --${arg.name}`, "EARG");
     }
+
+    if (arg.validator) {
+      const result = arg.validator(parsedArgsProxy[arg.name], arg);
+      if (typeof result === "string" && result.length > 0) {
+        throw new CLIError(
+          `Invalid value for argument ${cyan(`--${arg.name}`)}: ${result}`,
+          "EARG",
+        );
+      }
+    }
   }
 
   return parsedArgsProxy as ParsedArgs<T>;

--- a/src/types.ts
+++ b/src/types.ts
@@ -12,6 +12,12 @@ export type _ArgDef<T extends ArgType, VT extends boolean | number | string> = {
   default?: VT;
   required?: boolean;
   options?: string[];
+  /**
+   * Optional client validation hook invoked after citty parses and type-checks
+   * the argument value. Return `true` to accept, or a `string` error message
+   * to reject (citty throws a CLIError with that message). See issue #84.
+   */
+  validator?: (value: VT, arg: Arg) => boolean | string;
 };
 
 export type BooleanArgDef = Omit<_ArgDef<"boolean", boolean>, "options"> & {


### PR DESCRIPTION
Closes #84.

Add a `validator?: (value, arg) => boolean | string` to the arg definition: after citty parses and type checks the argument value, the validator is invoked. Return true to accept, or a string error message to reject (citty throws a CLIError with that message and the EARG code). Runs after the existing required/enum checks, so those still throw first.