### PR TITLE
feat: add number type to args (auto parse + throw on invalid)

### DIFF
--- a/src/args.ts
+++ b/src/args.ts
@@ -21,12 +21,12 @@ export function parseArgs<T extends ArgsDef = ArgsDef>(
     if (arg.type === "positional") {
       continue;
     }
-    if (arg.type === "string" || arg.type === "enum") {
+    if (arg.type === "string" || arg.type === "enum" || arg.type === "number") {
       parseOptions.string.push(arg.name);
     } else if (arg.type === "boolean") {
       parseOptions.boolean.push(arg.name);
     }
-    if (arg.default !== undefined) {
+    if (arg.default !== undefined && arg.type !== "number") {
       parseOptions.default[arg.name] = arg.default;
     }
     if (arg.alias) {
@@ -81,7 +81,26 @@ export function parseArgs<T extends ArgsDef = ArgsDef>(
           "EARG",
         );
       }
-    } else if (arg.required && parsedArgsProxy[arg.name] === undefined) {
+    }
+
+    if (arg.type === "number") {
+      let raw = parsedArgsProxy[arg.name];
+      if (raw === undefined && arg.default !== undefined) {
+        raw = arg.default as string | number;
+      }
+      if (raw !== undefined) {
+        const num = Number(raw);
+        if (Number.isNaN(num)) {
+          throw new CLIError(
+            `Invalid number value for argument: ${cyan(`--${arg.name}`)} (${cyan(raw)}).`,
+            "EARG",
+          );
+        }
+        parsedArgsProxy[arg.name] = num;
+      }
+    }
+
+    if (arg.required && parsedArgsProxy[arg.name] === undefined) {
       throw new CLIError(`Missing required argument: --${arg.name}`, "EARG");
     }
   }

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,6 +1,6 @@
 // ----- Args -----
 
-export type ArgType = "boolean" | "string" | "enum" | "positional" | undefined;
+export type ArgType = "boolean" | "string" | "number" | "enum" | "positional" | undefined;
 
 // Args: Definition
 
@@ -18,10 +18,16 @@ export type BooleanArgDef = Omit<_ArgDef<"boolean", boolean>, "options"> & {
   negativeDescription?: string;
 };
 export type StringArgDef = Omit<_ArgDef<"string", string>, "options">;
+export type NumberArgDef = Omit<_ArgDef<"number", number>, "options">;
 export type EnumArgDef = _ArgDef<"enum", string>;
 export type PositionalArgDef = Omit<_ArgDef<"positional", string>, "alias" | "options">;
 
-export type ArgDef = BooleanArgDef | StringArgDef | PositionalArgDef | EnumArgDef;
+export type ArgDef =
+  | BooleanArgDef
+  | StringArgDef
+  | NumberArgDef
+  | PositionalArgDef
+  | EnumArgDef;
 
 export type ArgsDef = Record<string, ArgDef>;
 
@@ -48,6 +54,10 @@ type ParsedStringArg<T extends ArgDef> = T extends { type: "string" }
   ? ResolveParsedArgType<T, string>
   : never;
 
+type ParsedNumberArg<T extends ArgDef> = T extends { type: "number" }
+  ? ResolveParsedArgType<T, number>
+  : never;
+
 type ParsedBooleanArg<T extends ArgDef> = T extends { type: "boolean" }
   ? ResolveParsedArgType<T, boolean>
   : never;
@@ -70,6 +80,7 @@ type ParsedArg<T extends ArgDef> =
   T["type"] extends "positional" ? ParsedPositionalArg<T> :
   T["type"] extends "boolean" ? ParsedBooleanArg<T> :
   T["type"] extends "string" ? ParsedStringArg<T> :
+  T["type"] extends "number" ? ParsedNumberArg<T> :
   T["type"] extends "enum" ? ParsedEnumArg<T> :
   never;
 


### PR DESCRIPTION
Closes #138.

Add a "number" ArgType: citty parses the value with Number(), throws a CLIError (EARG) when it is NaN, and exposes it as a number. Numeric defaults are applied by citty (not the underlying string parsing layer, which only supports string/boolean defaults) so the default is preserved. Required still applies to number args.