### PR TITLE
feat: support multiple positional args (multiPositional type)

### DIFF
--- a/src/args.ts
+++ b/src/args.ts
@@ -60,7 +60,21 @@ export function parseArgs<T extends ArgsDef = ArgsDef>(
   });
 
   for (const [, arg] of args.entries()) {
-    if (arg.type === "positional") {
+    if (arg.type === "multiPositional") {
+      if (positionalArguments.length > 0) {
+        parsedArgsProxy[arg.name] = [...positionalArguments];
+        positionalArguments.length = 0;
+      } else if (arg.default !== undefined) {
+        parsedArgsProxy[arg.name] = arg.default;
+      } else if (arg.required === true) {
+        throw new CLIError(
+          `Missing required positional argument: ${arg.name.toUpperCase()}`,
+          "EARG",
+        );
+      } else {
+        parsedArgsProxy[arg.name] = [];
+      }
+    } else if (arg.type === "positional") {
       const nextPositionalArgument = positionalArguments.shift();
       if (nextPositionalArgument !== undefined) {
         parsedArgsProxy[arg.name] = nextPositionalArgument;

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,10 +1,10 @@
 // ----- Args -----
 
-export type ArgType = "boolean" | "string" | "enum" | "positional" | undefined;
+export type ArgType = "boolean" | "string" | "enum" | "positional" | "multiPositional" | undefined;
 
 // Args: Definition
 
-export type _ArgDef<T extends ArgType, VT extends boolean | number | string> = {
+export type _ArgDef<T extends ArgType, VT extends boolean | number | string | unknown[]> = {
   type?: T;
   description?: string;
   valueHint?: string;
@@ -20,8 +20,14 @@ export type BooleanArgDef = Omit<_ArgDef<"boolean", boolean>, "options"> & {
 export type StringArgDef = Omit<_ArgDef<"string", string>, "options">;
 export type EnumArgDef = _ArgDef<"enum", string>;
 export type PositionalArgDef = Omit<_ArgDef<"positional", string>, "alias" | "options">;
+export type MultiPositionalArgDef = Omit<_ArgDef<"multiPositional", string[]>, "alias" | "options">;
 
-export type ArgDef = BooleanArgDef | StringArgDef | PositionalArgDef | EnumArgDef;
+export type ArgDef =
+  | BooleanArgDef
+  | StringArgDef
+  | PositionalArgDef
+  | MultiPositionalArgDef
+  | EnumArgDef;
 
 export type ArgsDef = Record<string, ArgDef>;
 
@@ -42,6 +48,12 @@ type ResolveParsedArgType<T extends ArgDef, VT> = T extends {
 
 type ParsedPositionalArg<T extends ArgDef> = T extends { type: "positional" }
   ? ResolveParsedArgType<T, string>
+  : never;
+
+type ParsedMultiPositionalArg<T extends ArgDef> = T extends {
+  type: "multiPositional";
+}
+  ? ResolveParsedArgType<T, string[]>
   : never;
 
 type ParsedStringArg<T extends ArgDef> = T extends { type: "string" }
@@ -68,6 +80,7 @@ type RawArgs = {
 // prettier-ignore
 type ParsedArg<T extends ArgDef> =
   T["type"] extends "positional" ? ParsedPositionalArg<T> :
+  T["type"] extends "multiPositional" ? ParsedMultiPositionalArg<T> :
   T["type"] extends "boolean" ? ParsedBooleanArg<T> :
   T["type"] extends "string" ? ParsedStringArg<T> :
   T["type"] extends "enum" ? ParsedEnumArg<T> :


### PR DESCRIPTION
Closes #115.

Add a "multiPositional" ArgType that collects all remaining positional arguments into a string[]. Optional by default (returns [] when none are provided); honours an explicit required:true (throws Missing required positional). Supports a default array.