### PR TITLE
feat: support hidden args

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,14 +164,14 @@ Plugin `setup` hooks run before the command's `setup` (in order), `cleanup` hook
 
 ### Common Options
 
-| Option        | Description                                                   |
-| ------------- | ------------------------------------------------------------- |
-| `description` | Help text shown in usage output                               |
-| `required`    | Whether the argument is required                              |
-| `default`     | Default value when not provided                               |
-| `alias`       | Short aliases (e.g., `["f"]`). Not for `positional`           |
-| `valueHint`   | Display hint in help (e.g., `"host"` renders `--name=<host>`) |
-| `hidden`      | Omit from usage output while still parsing the argument       |
+| Option        | Description                                                      |
+| ------------- | ---------------------------------------------------------------- |
+| `description` | Help text shown in usage output                                  |
+| `required`    | Whether the argument is required                                 |
+| `default`     | Default value when not provided                                  |
+| `alias`       | Short aliases (e.g., `["f"]`). Not for `positional`              |
+| `valueHint`   | Display hint in help (e.g., `"host"` renders `--name=<host>`)    |
+| `hidden`      | Omit from usage output while still parsing. Not for `positional` |
 
 ### Example
 

--- a/README.md
+++ b/README.md
@@ -171,6 +171,7 @@ Plugin `setup` hooks run before the command's `setup` (in order), `cleanup` hook
 | `default`     | Default value when not provided                               |
 | `alias`       | Short aliases (e.g., `["f"]`). Not for `positional`           |
 | `valueHint`   | Display hint in help (e.g., `"host"` renders `--name=<host>`) |
+| `hidden`      | Omit from usage output while still parsing the argument       |
 
 ### Example
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -20,7 +20,7 @@ export type BooleanArgDef = Omit<_ArgDef<"boolean", boolean>, "options"> & {
 };
 export type StringArgDef = Omit<_ArgDef<"string", string>, "options">;
 export type EnumArgDef = _ArgDef<"enum", string>;
-export type PositionalArgDef = Omit<_ArgDef<"positional", string>, "alias" | "options">;
+export type PositionalArgDef = Omit<_ArgDef<"positional", string>, "alias" | "options" | "hidden">;
 
 export type ArgDef = BooleanArgDef | StringArgDef | PositionalArgDef | EnumArgDef;
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -8,6 +8,7 @@ export type _ArgDef<T extends ArgType, VT extends boolean | number | string> = {
   type?: T;
   description?: string;
   valueHint?: string;
+  hidden?: boolean;
   alias?: string | string[];
   default?: VT;
   required?: boolean;

--- a/src/usage.ts
+++ b/src/usage.ts
@@ -35,15 +35,15 @@ export async function renderUsage<T extends ArgsDef = ArgsDef>(
   const usageLine = [];
 
   for (const arg of cmdArgs) {
-    if (arg.hidden) {
-      continue;
-    }
     if (arg.type === "positional") {
       const name = arg.name.toUpperCase();
       const isRequired = arg.required !== false && arg.default === undefined;
       posLines.push([colors.cyan(name + renderValueHint(arg)), renderDescription(arg, isRequired)]);
       usageLine.push(isRequired ? `<${name}>` : `[${name}]`);
     } else {
+      if (arg.hidden) {
+        continue;
+      }
       const isRequired = arg.required === true && arg.default === undefined;
       const argStr =
         [...(arg.alias || []).map((a) => `-${a}`), `--${arg.name}`].join(", ") +

--- a/src/usage.ts
+++ b/src/usage.ts
@@ -35,6 +35,9 @@ export async function renderUsage<T extends ArgsDef = ArgsDef>(
   const usageLine = [];
 
   for (const arg of cmdArgs) {
+    if (arg.hidden) {
+      continue;
+    }
     if (arg.type === "positional") {
       const name = arg.name.toUpperCase();
       const isRequired = arg.required !== false && arg.default === undefined;

--- a/test/usage.test.ts
+++ b/test/usage.test.ts
@@ -278,11 +278,6 @@ describe("usage", () => {
           negativeDescription: "Disable legacy",
           hidden: true,
         },
-        secretPos: {
-          type: "positional",
-          description: "A secret positional",
-          hidden: true,
-        },
         rootDir: {
           type: "positional",
           description: "A root dir",

--- a/test/usage.test.ts
+++ b/test/usage.test.ts
@@ -1,6 +1,6 @@
 import { expect, it, describe } from "vitest";
 import { renderUsage } from "../src/usage.ts";
-import { defineCommand } from "../src/index.ts";
+import { defineCommand, parseArgs } from "../src/index.ts";
 
 describe("usage", () => {
   it("renders arguments", async () => {
@@ -258,6 +258,68 @@ describe("usage", () => {
 
       Use Commander <command> --help for more information about a command."
     `);
+  });
+
+  it("does not render hidden args", async () => {
+    const command = defineCommand({
+      meta: {
+        name: "Commander",
+        description: "A command",
+      },
+      args: {
+        cwd: {
+          type: "string",
+          description: "A cwd",
+          hidden: true,
+        },
+        legacy: {
+          type: "boolean",
+          default: true,
+          negativeDescription: "Disable legacy",
+          hidden: true,
+        },
+        secretPos: {
+          type: "positional",
+          description: "A secret positional",
+          hidden: true,
+        },
+        rootDir: {
+          type: "positional",
+          description: "A root dir",
+        },
+        verbose: {
+          type: "boolean",
+          description: "Be verbose",
+        },
+      },
+    });
+
+    const usage = await renderUsage(command);
+
+    expect(usage).toMatchInlineSnapshot(`
+      "A command (Commander)
+
+      USAGE Commander [OPTIONS] <ROOTDIR>
+
+      ARGUMENTS
+
+        ROOTDIR    A root dir (Required)
+
+      OPTIONS
+
+        --verbose    Be verbose
+      "
+    `);
+  });
+
+  it("still parses hidden args", async () => {
+    const args = parseArgs(["--cwd", "/tmp", "--no-legacy"], {
+      cwd: { type: "string", hidden: true },
+      legacy: { type: "boolean", default: true, hidden: true },
+    });
+
+    expect(args.cwd).toBe("/tmp");
+    expect(args.legacy).toBe(false);
   });
 
   it("uses parents meta to explain how to run sub commands", async () => {


### PR DESCRIPTION
similar to hidden subcommands, this allows us to hide args (which we might, for example, want to keep for backwards compatibility)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a `hidden` argument option to omit specific arguments from rendered usage/help output while keeping them parsed and usable.
* **Documentation**
  * Updated the README “Common Options” table to document the new `hidden` behavior.
* **Bug Fixes**
  * Ensured hidden boolean arguments (including negated forms) continue to parse correctly.
* **Tests**
  * Added coverage for `renderUsage` skipping hidden arguments and confirmed `parseArgs` still reads values for hidden options.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->