### PR TITLE
fix: skip parent run() when subcommand executes, support = in alias values

### DIFF
--- a/src/_parser.ts
+++ b/src/_parser.ts
@@ -124,6 +124,13 @@ export function parseRawArgs<T = Record<string, any>>(
       continue;
     }
 
+    // Handle -x=value (single-dash alias with = separator)
+    if (arg.startsWith("-") && !arg.startsWith("--") && arg.includes("=")) {
+      const eqIndex = arg.indexOf("=");
+      processedArgs.push(arg.slice(0, eqIndex), arg.slice(eqIndex + 1));
+      continue;
+    }
+
     processedArgs.push(arg);
   }
 

--- a/src/command.ts
+++ b/src/command.ts
@@ -36,6 +36,7 @@ export async function runCommand<T extends ArgsDef = ArgsDef>(
 
   let result: unknown;
   let runError: unknown;
+  let subCommandExecuted = false;
   try {
     // Plugin setup hooks
     for (const plugin of plugins) {
@@ -58,6 +59,7 @@ export async function runCommand<T extends ArgsDef = ArgsDef>(
         if (!subCommand) {
           throw new CLIError(`Unknown command ${cyan(explicitName)}`, "E_UNKNOWN_COMMAND");
         }
+        subCommandExecuted = true;
         await runCommand(subCommand, {
           rawArgs: opts.rawArgs.slice(subCommandArgIndex + 1),
         });
@@ -78,6 +80,7 @@ export async function runCommand<T extends ArgsDef = ArgsDef>(
               "E_UNKNOWN_COMMAND",
             );
           }
+          subCommandExecuted = true;
           await runCommand(subCommand, {
             rawArgs: opts.rawArgs,
           });
@@ -87,8 +90,8 @@ export async function runCommand<T extends ArgsDef = ArgsDef>(
       }
     }
 
-    // Handle main command
-    if (typeof cmd.run === "function") {
+    // Handle main command (skip if a subcommand was executed)
+    if (!subCommandExecuted && typeof cmd.run === "function") {
       result = await cmd.run(context);
     }
   } catch (error) {

--- a/test/main.test.ts
+++ b/test/main.test.ts
@@ -143,6 +143,29 @@ describe("sub command", () => {
   });
 });
 
+  it("does not run parent command's run() when subcommand is executed (#253)", async () => {
+    const parentRunMock = vi.fn();
+    const subRunMock = vi.fn();
+
+    const command = defineCommand({
+      subCommands: {
+        foo: {
+          run: async () => {
+            subRunMock();
+          },
+        },
+      },
+      run: async () => {
+        parentRunMock();
+      },
+    });
+
+    await runMain(command, { rawArgs: ["foo"] });
+
+    expect(parentRunMock).not.toHaveBeenCalled();
+    expect(subRunMock).toHaveBeenCalledOnce();
+  });
+
 describe("sub command aliases", () => {
   it("resolves subcommand by single alias", async () => {
     const runMock = vi.fn();

--- a/test/parser.test.ts
+++ b/test/parser.test.ts
@@ -26,7 +26,7 @@ describe("parseRawArgs", () => {
     });
   });
 
-  it.fails("handles -<arg>=<value> with alias (#237)", () => {
+  it("handles -<arg>=<value> with alias (#237)", () => {
     const result = parseRawArgs(["-n=John"], {
       string: ["name"],
       alias: {


### PR DESCRIPTION
## Fixes

### #253 - Parent command's run() executes when subcommand runs

When a subcommand is explicitly provided and executed, the parent command's `run()` function was still being called. This caused both the subcommand and parent to execute their `run()` logic.

**Fix:** Added a `subCommandExecuted` flag that is set to `true` when a subcommand is found and executed. The parent's `run()` is now gated behind `!subCommandExecuted`.

### #237 - Alias values with `=` separator (e.g. `-n=John`)

The native Node.js `parseArgs` includes the `=` in the value when a single-dash alias uses `=` syntax (e.g., `-n=John` is parsed as `n: "=John"`).

**Fix:** Added preprocessing in `parseRawArgs` that splits single-dash args on the first `=` into separate tokens (`[-n, John]`) before passing them to Node.js `parseArgs`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for single-dash options with values, such as `-x=value`, treating them consistently with option aliases.

* **Bug Fixes**
  * Prevented a parent command from running when a subcommand is selected, avoiding unintended duplicate command execution.
  * Confirmed previously unsupported alias-value syntax now works as expected.

* **Tests**
  * Added coverage ensuring only the selected subcommand runs when applicable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->