### PR TITLE
fix: respect argument order for --no-<flag> negation

### DIFF
--- a/src/_parser.ts
+++ b/src/_parser.ts
@@ -106,7 +106,6 @@ export function parseRawArgs<T = Record<string, any>>(
 
   // Handle --no- prefixed arguments by preprocessing
   const processedArgs: string[] = [];
-  const negatedFlags: Record<string, boolean> = {};
 
   for (let i = 0; i < args.length; i++) {
     const arg = args[i]!;
@@ -117,10 +116,13 @@ export function parseRawArgs<T = Record<string, any>>(
       break;
     }
 
-    // Handle --no-flag syntax
+    // Rewrite --no-<flag> to --<flag>=false in place so token order is
+    // preserved: node:util keeps the last occurrence (as it already does for
+    // value flags), the coercion below turns "false" into a boolean, and the
+    // alias-propagation pass handles aliases. A previous positive like
+    // `--no-x --x` is no longer clobbered by an order-insensitive override.
     if (arg.startsWith("--no-")) {
-      const flagName = arg.slice(5);
-      negatedFlags[flagName] = true;
+      processedArgs.push(`--${arg.slice(5)}=false`);
       continue;
     }
 
@@ -157,26 +159,6 @@ export function parseRawArgs<T = Record<string, any>>(
       coerced = "";
     }
     (out as any)[key] = coerced;
-  }
-
-  // Apply negated flags (with alias resolution)
-  for (const [name] of Object.entries(negatedFlags)) {
-    // Set the flag itself
-    (out as any)[name] = false;
-
-    // Resolve to main option and apply there too (handles --no-alias)
-    const mainName = aliasToMain.get(name);
-    if (mainName) {
-      (out as any)[mainName] = false;
-    }
-
-    // Also apply to all aliases of this name (handles --no-main for aliases)
-    const aliases = mainToAliases.get(name);
-    if (aliases) {
-      for (const alias of aliases) {
-        (out as any)[alias] = false;
-      }
-    }
   }
 
   // Propagate values between aliases

--- a/test/parser.test.ts
+++ b/test/parser.test.ts
@@ -161,6 +161,15 @@ describe("parseRawArgs", () => {
     });
   });
 
+  it("respects token order for --no- negation (a later positive wins)", () => {
+    const result = parseRawArgs(["--no-verbose", "--verbose"], {
+      boolean: ["verbose"],
+      default: { verbose: true },
+    });
+    // Value flags already honor last-wins; boolean negation must too.
+    expect(result.verbose).toBe(true);
+  });
+
   it("coerces --flag=true to boolean true for boolean args", () => {
     const result = parseRawArgs(["--flag=true"], { boolean: ["flag"] });
     expect(result.flag).toBe(true);


### PR DESCRIPTION
## Summary

`--no-<flag>` ignores token order, so a later explicit positive is silently overridden to `false`:

```js
parseRawArgs(["--no-verbose", "--verbose"], { boolean: ["verbose"], default: { verbose: true } })
// → { _: [], verbose: false }   (expected verbose: true)
```

In `src/_parser.ts`, `--no-<flag>` is removed from the arg stream during preprocessing and recorded in `negatedFlags`, then applied **after** `node:util.parseArgs` in a pass that runs unconditionally regardless of where `--no-x` sat relative to a later `--x`:

```ts
if (arg.startsWith("--no-")) { negatedFlags[flagName] = true; continue; }
// ...later...
for (const [name] of Object.entries(negatedFlags)) { (out as any)[name] = false; /* + aliases */ }
```

This is inconsistent with the parser's own value flags, which already honor last-wins (`["--name","a","--name","b"]` → `"b"`). The result is a *silent* wrong boolean — e.g. a wrapper/alias injects `--no-install` and the user's explicit `--install` at the end is ignored.

## Fix

Rewrite `--no-<flag>` to `--<flag>=false` **in place**, preserving order, and remove the order-insensitive post-hoc override:

```ts
if (arg.startsWith("--no-")) {
  processedArgs.push(`--${arg.slice(5)}=false`);
  continue;
}
```

`node:util` keeps the last occurrence, the existing coercion (`value !== "false"`) turns it into a boolean, and the existing alias-propagation pass still fans `--no-<alias>` / `--no-<main>` out to their counterparts.

## Testing

- Added a regression test: `["--no-verbose", "--verbose"]` → `verbose: true`.
- All existing negation/alias tests still pass (`--no-verbose` on main, `--no-v` → main, `--no-verbose` → aliases), and the full suite is green (110 passed, 1 pre-existing `expected fail`). `--typecheck` clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed boolean command-line flags so a later positive flag correctly overrides an earlier `--no-` flag.
  * Improved consistency when resolving repeated flags and their aliases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->