### PR TITLE
feat(args): support inheriting parent args in sub commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,18 +164,18 @@ Plugin `setup` hooks run before the command's `setup` (in order), `cleanup` hook
 
 ### Common Options
 
-| Option        | Description                                                    |
-| ------------- | -------------------------------------------------------------- |
-| `description` | Help text shown in usage output                                |
-| `required`    | Whether the argument is required                               |
-| `default`     | Default value when not provided                                |
-| `alias`       | Short aliases (e.g., `["f"]`). Not for `positional`            |
-| `valueHint`   | Display hint in help (e.g., `"host"` renders `--name=<host>`)  |
-| `inherit`     | Make the arg reachable from sub commands. Not for `positional` |
+| Option        | Description                                                   |
+| ------------- | ------------------------------------------------------------- |
+| `description` | Help text shown in usage output                               |
+| `required`    | Whether the argument is required                              |
+| `default`     | Default value when not provided                               |
+| `alias`       | Short aliases (e.g., `["f"]`). Not for `positional`           |
+| `valueHint`   | Display hint in help (e.g., `"host"` renders `--name=<host>`) |
+| `inherit`     | Also parse the arg in sub commands. Not for `positional`      |
 
 ### Inherited Arguments
 
-By default, args passed before a sub command name are consumed by the parent only. Mark an arg with `inherit: true` to also make it available to sub commands, so `cli --cwd playground dev` and `cli dev --cwd playground` are equivalent:
+Args passed before a sub command name are consumed by the parent only, unless marked `inherit: true`, which also makes them available to sub commands:
 
 ```js
 const main = defineCommand({
@@ -183,8 +183,6 @@ const main = defineCommand({
   subCommands: { dev },
 });
 ```
-
-The arg definition is forwarded too, so sub commands do not need to redeclare it. A sub command that declares the same name wins, as does a value passed after the sub command name.
 
 ### Example
 

--- a/README.md
+++ b/README.md
@@ -164,13 +164,27 @@ Plugin `setup` hooks run before the command's `setup` (in order), `cleanup` hook
 
 ### Common Options
 
-| Option        | Description                                                   |
-| ------------- | ------------------------------------------------------------- |
-| `description` | Help text shown in usage output                               |
-| `required`    | Whether the argument is required                              |
-| `default`     | Default value when not provided                               |
-| `alias`       | Short aliases (e.g., `["f"]`). Not for `positional`           |
-| `valueHint`   | Display hint in help (e.g., `"host"` renders `--name=<host>`) |
+| Option        | Description                                                    |
+| ------------- | -------------------------------------------------------------- |
+| `description` | Help text shown in usage output                                |
+| `required`    | Whether the argument is required                               |
+| `default`     | Default value when not provided                                |
+| `alias`       | Short aliases (e.g., `["f"]`). Not for `positional`            |
+| `valueHint`   | Display hint in help (e.g., `"host"` renders `--name=<host>`)  |
+| `inherit`     | Make the arg reachable from sub commands. Not for `positional` |
+
+### Inherited Arguments
+
+By default, args passed before a sub command name are consumed by the parent only. Mark an arg with `inherit: true` to also make it available to sub commands, so `cli --cwd playground dev` and `cli dev --cwd playground` are equivalent:
+
+```js
+const main = defineCommand({
+  args: { cwd: { type: "string", default: ".", inherit: true } },
+  subCommands: { dev },
+});
+```
+
+The arg definition is forwarded too, so sub commands do not need to redeclare it. A sub command that declares the same name wins, as does a value passed after the sub command name.
 
 ### Example
 

--- a/src/command.ts
+++ b/src/command.ts
@@ -1,5 +1,5 @@
 import { camelCase } from "scule";
-import type { CommandContext, CommandDef, ArgsDef, SubCommandsDef } from "./types.ts";
+import type { ArgDef, ArgsDef, CommandContext, CommandDef, SubCommandsDef } from "./types.ts";
 import { CLIError, resolveValue, toArray } from "./_utils.ts";
 import { parseArgs } from "./args.ts";
 import { cyan } from "./_color.ts";
@@ -15,13 +15,18 @@ export interface RunCommandOptions {
   rawArgs: string[];
   data?: any;
   showUsage?: boolean;
+  /**
+   * Args declared with `inherit` by a parent command, forwarded so this command can
+   * parse them even when it does not declare them itself.
+   */
+  inheritedArgs?: ArgsDef;
 }
 
 export async function runCommand<T extends ArgsDef = ArgsDef>(
   cmd: CommandDef<T>,
   opts: RunCommandOptions,
 ): Promise<{ result: unknown }> {
-  const cmdArgs = await resolveValue(cmd.args || {});
+  const cmdArgs: ArgsDef = { ...opts.inheritedArgs, ...(await resolveValue(cmd.args || {})) };
   const parsedArgs = parseArgs<T>(opts.rawArgs, cmdArgs);
 
   const context: CommandContext<T> = {
@@ -58,8 +63,17 @@ export async function runCommand<T extends ArgsDef = ArgsDef>(
         if (!subCommand) {
           throw new CLIError(`Unknown command ${cyan(explicitName)}`, "E_UNKNOWN_COMMAND");
         }
+        const inheritedArgs = _inheritedArgs(cmdArgs);
         await runCommand(subCommand, {
-          rawArgs: opts.rawArgs.slice(subCommandArgIndex + 1),
+          rawArgs: [
+            ..._collectInheritedRawArgs(
+              opts.rawArgs.slice(0, subCommandArgIndex),
+              cmdArgs,
+              inheritedArgs,
+            ),
+            ...opts.rawArgs.slice(subCommandArgIndex + 1),
+          ],
+          inheritedArgs,
         });
       } else {
         // No explicit sub command — check for default
@@ -80,6 +94,7 @@ export async function runCommand<T extends ArgsDef = ArgsDef>(
           }
           await runCommand(subCommand, {
             rawArgs: opts.rawArgs,
+            inheritedArgs: _inheritedArgs(cmdArgs),
           });
         } else if (!cmd.run) {
           throw new CLIError(`No command specified.`, "E_NO_COMMAND");
@@ -184,13 +199,62 @@ function findSubCommandIndex(rawArgs: string[], argsDef: ArgsDef): number {
 }
 
 function _isValueFlag(flag: string, argsDef: ArgsDef): boolean {
-  const name = flag.replace(/^-{1,2}/, "");
+  return (
+    _matchArg(flag, argsDef, (def) => def.type === "string" || def.type === "enum") !== undefined
+  );
+}
+
+function _matchArg(
+  flag: string,
+  argsDef: ArgsDef,
+  filter: (def: ArgDef) => boolean,
+): ArgDef | undefined {
+  const name = flag.replace(/^-{1,2}/, "").replace(/^no-/, "");
   const normalized = camelCase(name);
   for (const [key, def] of Object.entries(argsDef)) {
-    if (def.type !== "string" && def.type !== "enum") continue;
-    if (normalized === camelCase(key)) return true;
-    const aliases = Array.isArray(def.alias) ? def.alias : def.alias ? [def.alias] : [];
-    if (aliases.includes(name)) return true;
+    if (!filter(def)) continue;
+    if (normalized === camelCase(key)) return def;
+    if (toArray((def as { alias?: string | string[] }).alias).includes(name)) return def;
   }
-  return false;
+}
+
+function _inheritedArgs(argsDef: ArgsDef): ArgsDef {
+  const inherited: ArgsDef = {};
+  for (const [name, def] of Object.entries(argsDef)) {
+    if (def.type !== "positional" && (def as { inherit?: boolean }).inherit) {
+      inherited[name] = def;
+    }
+  }
+  return inherited;
+}
+
+/**
+ * Pick out the tokens of inherited args from the args consumed before a sub command name,
+ * so they can be re-parsed by the sub command. Positionals are left behind.
+ */
+function _collectInheritedRawArgs(
+  rawArgs: string[],
+  argsDef: ArgsDef,
+  inherited: ArgsDef,
+): string[] {
+  if (Object.keys(inherited).length === 0) {
+    return [];
+  }
+  const collected: string[] = [];
+  for (let i = 0; i < rawArgs.length; i++) {
+    const arg = rawArgs[i]!;
+    if (!arg.startsWith("-")) continue;
+    const [flag] = arg.split("=", 1) as [string];
+    const takesValue = !arg.includes("=") && _isValueFlag(flag, argsDef);
+    if (_matchArg(flag, inherited, () => true)) {
+      collected.push(arg);
+      if (takesValue && i + 1 < rawArgs.length) {
+        collected.push(rawArgs[i + 1]!);
+      }
+    }
+    if (takesValue) {
+      i++;
+    }
+  }
+  return collected;
 }

--- a/src/command.ts
+++ b/src/command.ts
@@ -15,10 +15,6 @@ export interface RunCommandOptions {
   rawArgs: string[];
   data?: any;
   showUsage?: boolean;
-  /**
-   * Args declared with `inherit` by a parent command, forwarded so this command can
-   * parse them even when it does not declare them itself.
-   */
   inheritedArgs?: ArgsDef;
 }
 
@@ -209,7 +205,20 @@ function _matchArg(
   argsDef: ArgsDef,
   filter: (def: ArgDef) => boolean,
 ): ArgDef | undefined {
-  const name = flag.replace(/^-{1,2}/, "").replace(/^no-/, "");
+  const name = flag.replace(/^-{1,2}/, "");
+  const direct = _findArg(name, argsDef, filter);
+  if (direct || !name.startsWith("no-")) {
+    return direct;
+  }
+  // `--no-x` only ever refers to a boolean `x`, and never consumes a value
+  return _findArg(name.slice(3), argsDef, (def) => def.type === "boolean" && filter(def));
+}
+
+function _findArg(
+  name: string,
+  argsDef: ArgsDef,
+  filter: (def: ArgDef) => boolean,
+): ArgDef | undefined {
   const normalized = camelCase(name);
   for (const [key, def] of Object.entries(argsDef)) {
     if (!filter(def)) continue;
@@ -228,10 +237,6 @@ function _inheritedArgs(argsDef: ArgsDef): ArgsDef {
   return inherited;
 }
 
-/**
- * Pick out the tokens of inherited args from the args consumed before a sub command name,
- * so they can be re-parsed by the sub command. Positionals are left behind.
- */
 function _collectInheritedRawArgs(
   rawArgs: string[],
   argsDef: ArgsDef,

--- a/src/types.ts
+++ b/src/types.ts
@@ -12,10 +12,6 @@ export type _ArgDef<T extends ArgType, VT extends boolean | number | string> = {
   default?: VT;
   required?: boolean;
   options?: string[];
-  /**
-   * Make this argument available to sub commands, so it can be passed before the
-   * sub command name (`cli --cwd . dev`). Values passed after the sub command name win.
-   */
   inherit?: boolean;
 };
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -12,6 +12,11 @@ export type _ArgDef<T extends ArgType, VT extends boolean | number | string> = {
   default?: VT;
   required?: boolean;
   options?: string[];
+  /**
+   * Make this argument available to sub commands, so it can be passed before the
+   * sub command name (`cli --cwd . dev`). Values passed after the sub command name win.
+   */
+  inherit?: boolean;
 };
 
 export type BooleanArgDef = Omit<_ArgDef<"boolean", boolean>, "options"> & {
@@ -19,7 +24,7 @@ export type BooleanArgDef = Omit<_ArgDef<"boolean", boolean>, "options"> & {
 };
 export type StringArgDef = Omit<_ArgDef<"string", string>, "options">;
 export type EnumArgDef = _ArgDef<"enum", string>;
-export type PositionalArgDef = Omit<_ArgDef<"positional", string>, "alias" | "options">;
+export type PositionalArgDef = Omit<_ArgDef<"positional", string>, "alias" | "options" | "inherit">;
 
 export type ArgDef = BooleanArgDef | StringArgDef | PositionalArgDef | EnumArgDef;
 

--- a/test/inherit.test.ts
+++ b/test/inherit.test.ts
@@ -1,0 +1,191 @@
+import { describe, expect, it, vi } from "vitest";
+import { defineCommand, runCommand } from "../src/index.ts";
+
+describe("inherited args", () => {
+  it("should forward a parent arg declared before the sub command name", async () => {
+    const run = vi.fn();
+    const dev = defineCommand({
+      meta: { name: "dev" },
+      args: { cwd: { type: "string", default: "." } },
+      run,
+    });
+    const main = defineCommand({
+      meta: { name: "nuxt" },
+      args: {
+        cwd: { type: "string", default: ".", inherit: true },
+        command: { type: "positional", required: false },
+      },
+      subCommands: { dev },
+    });
+
+    await runCommand(main, { rawArgs: ["--cwd", "playground", "dev"] });
+
+    expect(run.mock.calls[0]![0].args.cwd).toBe("playground");
+    expect(run.mock.calls[0]![0].rawArgs).toEqual(["--cwd", "playground"]);
+  });
+
+  it("should not forward args without `inherit`", async () => {
+    const run = vi.fn();
+    const dev = defineCommand({
+      args: { cwd: { type: "string", default: "." } },
+      run,
+    });
+    const main = defineCommand({
+      args: {
+        cwd: { type: "string", default: "." },
+        command: { type: "positional", required: false },
+      },
+      subCommands: { dev },
+    });
+
+    await runCommand(main, { rawArgs: ["--cwd", "playground", "dev"] });
+
+    expect(run.mock.calls[0]![0].args.cwd).toBe(".");
+    expect(run.mock.calls[0]![0].rawArgs).toEqual([]);
+  });
+
+  it("should make inherited args available to sub commands that do not declare them", async () => {
+    const run = vi.fn();
+    const dev = defineCommand({ run });
+    const main = defineCommand({
+      args: { cwd: { type: "string", inherit: true } },
+      subCommands: { dev },
+    });
+
+    await runCommand(main, { rawArgs: ["--cwd", "playground", "dev"] });
+
+    expect(run.mock.calls[0]![0].args.cwd).toBe("playground");
+    expect(run.mock.calls[0]![0].args._).toEqual([]);
+  });
+
+  it("should support boolean, enum, alias and `=` forms", async () => {
+    const run = vi.fn();
+    const dev = defineCommand({ run });
+    const main = defineCommand({
+      args: {
+        verbose: { type: "boolean", inherit: true },
+        logLevel: { type: "enum", options: ["info", "warn"], alias: "l", inherit: true },
+        cwd: { type: "string", inherit: true },
+      },
+      subCommands: { dev },
+    });
+
+    await runCommand(main, {
+      rawArgs: ["--verbose", "-l", "warn", "--cwd=playground", "dev"],
+    });
+
+    const { args, rawArgs } = run.mock.calls[0]![0];
+    expect(args.verbose).toBe(true);
+    expect(args.logLevel).toBe("warn");
+    expect(args.cwd).toBe("playground");
+    expect(rawArgs).toEqual(["--verbose", "-l", "warn", "--cwd=playground"]);
+  });
+
+  it("should let a value passed after the sub command name win", async () => {
+    const run = vi.fn();
+    const dev = defineCommand({
+      args: { cwd: { type: "string", default: "." } },
+      run,
+    });
+    const main = defineCommand({
+      args: { cwd: { type: "string", default: ".", inherit: true } },
+      subCommands: { dev },
+    });
+
+    await runCommand(main, { rawArgs: ["--cwd", "parent", "dev", "--cwd", "child"] });
+
+    expect(run.mock.calls[0]![0].args.cwd).toBe("child");
+  });
+
+  it("should let the sub command's own definition win", async () => {
+    const run = vi.fn();
+    const dev = defineCommand({
+      args: { mode: { type: "string", default: "dev" } },
+      run,
+    });
+    const main = defineCommand({
+      args: { mode: { type: "enum", options: ["a", "b"], default: "a", inherit: true } },
+      subCommands: { dev },
+    });
+
+    await runCommand(main, { rawArgs: ["dev"] });
+
+    expect(run.mock.calls[0]![0].args.mode).toBe("dev");
+  });
+
+  it("should not apply the parent default over an explicit sub command value", async () => {
+    const run = vi.fn();
+    const dev = defineCommand({ run });
+    const main = defineCommand({
+      args: { cwd: { type: "string", default: ".", inherit: true } },
+      subCommands: { dev },
+    });
+
+    await runCommand(main, { rawArgs: ["dev", "--cwd", "playground"] });
+
+    expect(run.mock.calls[0]![0].args.cwd).toBe("playground");
+  });
+
+  it("should not consume a parent positional", async () => {
+    const run = vi.fn();
+    const dev = defineCommand({ run });
+    const main = defineCommand({
+      args: {
+        cwd: { type: "string", inherit: true },
+        command: { type: "positional", required: false },
+      },
+      subCommands: { dev },
+    });
+
+    await runCommand(main, { rawArgs: ["--cwd", "playground", "dev", "extra"] });
+
+    expect(run.mock.calls[0]![0].args._).toEqual(["extra"]);
+  });
+
+  it("should leave `--` passthrough untouched", async () => {
+    const run = vi.fn();
+    const dev = defineCommand({ run });
+    const main = defineCommand({
+      args: { cwd: { type: "string", inherit: true } },
+      subCommands: { dev },
+    });
+
+    await runCommand(main, {
+      rawArgs: ["--cwd", "playground", "dev", "--", "--cwd", "raw"],
+    });
+
+    const { args, rawArgs } = run.mock.calls[0]![0];
+    expect(rawArgs).toEqual(["--cwd", "playground", "--", "--cwd", "raw"]);
+    expect(args.cwd).toBe("playground");
+  });
+
+  it("should compose across nested sub commands", async () => {
+    const run = vi.fn();
+    const add = defineCommand({ run });
+    const module_ = defineCommand({ subCommands: { add } });
+    const main = defineCommand({
+      args: { cwd: { type: "string", inherit: true } },
+      subCommands: { module: module_ },
+    });
+
+    await runCommand(main, { rawArgs: ["--cwd", "playground", "module", "add", "nuxt-og-image"] });
+
+    const { args, rawArgs } = run.mock.calls[0]![0];
+    expect(args.cwd).toBe("playground");
+    expect(rawArgs).toEqual(["--cwd", "playground", "nuxt-og-image"]);
+  });
+
+  it("should forward inherited args to a default sub command", async () => {
+    const run = vi.fn();
+    const dev = defineCommand({ run });
+    const main = defineCommand({
+      args: { cwd: { type: "string", inherit: true } },
+      subCommands: { dev },
+      default: "dev",
+    });
+
+    await runCommand(main, { rawArgs: ["--cwd", "playground"] });
+
+    expect(run.mock.calls[0]![0].args.cwd).toBe("playground");
+  });
+});

--- a/test/inherit.test.ts
+++ b/test/inherit.test.ts
@@ -1,191 +1,250 @@
-import { describe, expect, it, vi } from "vitest";
+import { describe, it, expect, vi } from "vitest";
 import { defineCommand, runCommand } from "../src/index.ts";
 
 describe("inherited args", () => {
-  it("should forward a parent arg declared before the sub command name", async () => {
-    const run = vi.fn();
-    const dev = defineCommand({
-      meta: { name: "dev" },
-      args: { cwd: { type: "string", default: "." } },
-      run,
-    });
-    const main = defineCommand({
+  it("forwards a parent arg passed before the sub command name", async () => {
+    const runMock = vi.fn();
+
+    const command = defineCommand({
       meta: { name: "nuxt" },
       args: {
         cwd: { type: "string", default: ".", inherit: true },
         command: { type: "positional", required: false },
       },
-      subCommands: { dev },
+      subCommands: {
+        dev: {
+          meta: { name: "dev" },
+          args: { cwd: { type: "string", default: "." } },
+          run: ({ args, rawArgs }) => runMock(args.cwd, rawArgs),
+        },
+      },
     });
 
-    await runCommand(main, { rawArgs: ["--cwd", "playground", "dev"] });
+    await runCommand(command, { rawArgs: ["--cwd", "playground", "dev"] });
 
-    expect(run.mock.calls[0]![0].args.cwd).toBe("playground");
-    expect(run.mock.calls[0]![0].rawArgs).toEqual(["--cwd", "playground"]);
+    expect(runMock).toHaveBeenCalledWith("playground", ["--cwd", "playground"]);
   });
 
-  it("should not forward args without `inherit`", async () => {
-    const run = vi.fn();
-    const dev = defineCommand({
-      args: { cwd: { type: "string", default: "." } },
-      run,
-    });
-    const main = defineCommand({
+  it("does not forward args without `inherit`", async () => {
+    const runMock = vi.fn();
+
+    const command = defineCommand({
       args: {
         cwd: { type: "string", default: "." },
         command: { type: "positional", required: false },
       },
-      subCommands: { dev },
+      subCommands: {
+        dev: {
+          args: { cwd: { type: "string", default: "." } },
+          run: ({ args, rawArgs }) => runMock(args.cwd, rawArgs),
+        },
+      },
     });
 
-    await runCommand(main, { rawArgs: ["--cwd", "playground", "dev"] });
+    await runCommand(command, { rawArgs: ["--cwd", "playground", "dev"] });
 
-    expect(run.mock.calls[0]![0].args.cwd).toBe(".");
-    expect(run.mock.calls[0]![0].rawArgs).toEqual([]);
+    expect(runMock).toHaveBeenCalledWith(".", []);
   });
 
-  it("should make inherited args available to sub commands that do not declare them", async () => {
-    const run = vi.fn();
-    const dev = defineCommand({ run });
-    const main = defineCommand({
+  it("parses inherited args for a sub command that does not declare them", async () => {
+    const runMock = vi.fn();
+
+    const command = defineCommand({
       args: { cwd: { type: "string", inherit: true } },
-      subCommands: { dev },
+      subCommands: {
+        dev: { run: ({ args }) => runMock(args.cwd, args._) },
+      },
     });
 
-    await runCommand(main, { rawArgs: ["--cwd", "playground", "dev"] });
+    await runCommand(command, { rawArgs: ["--cwd", "playground", "dev"] });
 
-    expect(run.mock.calls[0]![0].args.cwd).toBe("playground");
-    expect(run.mock.calls[0]![0].args._).toEqual([]);
+    expect(runMock).toHaveBeenCalledWith("playground", []);
   });
 
-  it("should support boolean, enum, alias and `=` forms", async () => {
-    const run = vi.fn();
-    const dev = defineCommand({ run });
-    const main = defineCommand({
+  it("forwards boolean, alias, enum and `=` forms", async () => {
+    const runMock = vi.fn();
+
+    const command = defineCommand({
       args: {
         verbose: { type: "boolean", inherit: true },
         logLevel: { type: "enum", options: ["info", "warn"], alias: "l", inherit: true },
         cwd: { type: "string", inherit: true },
       },
-      subCommands: { dev },
+      subCommands: {
+        dev: {
+          run: ({ args, rawArgs }) => runMock(args.verbose, args.logLevel, args.cwd, rawArgs),
+        },
+      },
     });
 
-    await runCommand(main, {
+    await runCommand(command, {
       rawArgs: ["--verbose", "-l", "warn", "--cwd=playground", "dev"],
     });
 
-    const { args, rawArgs } = run.mock.calls[0]![0];
-    expect(args.verbose).toBe(true);
-    expect(args.logLevel).toBe("warn");
-    expect(args.cwd).toBe("playground");
-    expect(rawArgs).toEqual(["--verbose", "-l", "warn", "--cwd=playground"]);
+    expect(runMock).toHaveBeenCalledWith(true, "warn", "playground", [
+      "--verbose",
+      "-l",
+      "warn",
+      "--cwd=playground",
+    ]);
   });
 
-  it("should let a value passed after the sub command name win", async () => {
-    const run = vi.fn();
-    const dev = defineCommand({
-      args: { cwd: { type: "string", default: "." } },
-      run,
+  it("forwards a negated boolean without consuming the sub command name", async () => {
+    const runMock = vi.fn();
+
+    const command = defineCommand({
+      args: { color: { type: "boolean", default: true, inherit: true } },
+      subCommands: {
+        dev: { run: ({ args }) => runMock(args.color) },
+      },
     });
-    const main = defineCommand({
+
+    await runCommand(command, { rawArgs: ["--no-color", "dev"] });
+
+    expect(runMock).toHaveBeenCalledWith(false);
+  });
+
+  it("resolves the sub command after a negated string arg", async () => {
+    const runMock = vi.fn();
+
+    const command = defineCommand({
+      args: { cwd: { type: "string", inherit: true } },
+      subCommands: {
+        dev: { run: () => runMock() },
+      },
+    });
+
+    await runCommand(command, { rawArgs: ["--no-cwd", "dev"] });
+
+    expect(runMock).toHaveBeenCalledOnce();
+  });
+
+  it("prefers a value passed after the sub command name", async () => {
+    const runMock = vi.fn();
+
+    const command = defineCommand({
       args: { cwd: { type: "string", default: ".", inherit: true } },
-      subCommands: { dev },
+      subCommands: {
+        dev: {
+          args: { cwd: { type: "string", default: "." } },
+          run: ({ args }) => runMock(args.cwd),
+        },
+      },
     });
 
-    await runCommand(main, { rawArgs: ["--cwd", "parent", "dev", "--cwd", "child"] });
+    await runCommand(command, { rawArgs: ["--cwd", "parent", "dev", "--cwd", "child"] });
 
-    expect(run.mock.calls[0]![0].args.cwd).toBe("child");
+    expect(runMock).toHaveBeenCalledWith("child");
   });
 
-  it("should let the sub command's own definition win", async () => {
-    const run = vi.fn();
-    const dev = defineCommand({
-      args: { mode: { type: "string", default: "dev" } },
-      run,
-    });
-    const main = defineCommand({
+  it("prefers the sub command's own definition", async () => {
+    const runMock = vi.fn();
+
+    const command = defineCommand({
       args: { mode: { type: "enum", options: ["a", "b"], default: "a", inherit: true } },
-      subCommands: { dev },
+      subCommands: {
+        dev: {
+          args: { mode: { type: "string", default: "dev" } },
+          run: ({ args }) => runMock(args.mode),
+        },
+      },
     });
 
-    await runCommand(main, { rawArgs: ["dev"] });
+    await runCommand(command, { rawArgs: ["dev"] });
 
-    expect(run.mock.calls[0]![0].args.mode).toBe("dev");
+    expect(runMock).toHaveBeenCalledWith("dev");
   });
 
-  it("should not apply the parent default over an explicit sub command value", async () => {
-    const run = vi.fn();
-    const dev = defineCommand({ run });
-    const main = defineCommand({
+  it("does not apply the parent default over an explicit sub command value", async () => {
+    const runMock = vi.fn();
+
+    const command = defineCommand({
       args: { cwd: { type: "string", default: ".", inherit: true } },
-      subCommands: { dev },
+      subCommands: {
+        dev: { run: ({ args }) => runMock(args.cwd) },
+      },
     });
 
-    await runCommand(main, { rawArgs: ["dev", "--cwd", "playground"] });
+    await runCommand(command, { rawArgs: ["dev", "--cwd", "playground"] });
 
-    expect(run.mock.calls[0]![0].args.cwd).toBe("playground");
+    expect(runMock).toHaveBeenCalledWith("playground");
   });
 
-  it("should not consume a parent positional", async () => {
-    const run = vi.fn();
-    const dev = defineCommand({ run });
-    const main = defineCommand({
+  it("does not forward parent positionals", async () => {
+    const runMock = vi.fn();
+
+    const command = defineCommand({
       args: {
         cwd: { type: "string", inherit: true },
         command: { type: "positional", required: false },
       },
-      subCommands: { dev },
+      subCommands: {
+        dev: { run: ({ args }) => runMock(args._) },
+      },
     });
 
-    await runCommand(main, { rawArgs: ["--cwd", "playground", "dev", "extra"] });
+    await runCommand(command, { rawArgs: ["--cwd", "playground", "dev", "extra"] });
 
-    expect(run.mock.calls[0]![0].args._).toEqual(["extra"]);
+    expect(runMock).toHaveBeenCalledWith(["extra"]);
   });
 
-  it("should leave `--` passthrough untouched", async () => {
-    const run = vi.fn();
-    const dev = defineCommand({ run });
-    const main = defineCommand({
+  it("leaves `--` passthrough untouched", async () => {
+    const runMock = vi.fn();
+
+    const command = defineCommand({
       args: { cwd: { type: "string", inherit: true } },
-      subCommands: { dev },
+      subCommands: {
+        dev: { run: ({ args, rawArgs }) => runMock(args.cwd, rawArgs) },
+      },
     });
 
-    await runCommand(main, {
+    await runCommand(command, {
       rawArgs: ["--cwd", "playground", "dev", "--", "--cwd", "raw"],
     });
 
-    const { args, rawArgs } = run.mock.calls[0]![0];
-    expect(rawArgs).toEqual(["--cwd", "playground", "--", "--cwd", "raw"]);
-    expect(args.cwd).toBe("playground");
+    expect(runMock).toHaveBeenCalledWith("playground", [
+      "--cwd",
+      "playground",
+      "--",
+      "--cwd",
+      "raw",
+    ]);
   });
 
-  it("should compose across nested sub commands", async () => {
-    const run = vi.fn();
-    const add = defineCommand({ run });
-    const module_ = defineCommand({ subCommands: { add } });
-    const main = defineCommand({
+  it("composes across nested sub commands", async () => {
+    const runMock = vi.fn();
+
+    const command = defineCommand({
       args: { cwd: { type: "string", inherit: true } },
-      subCommands: { module: module_ },
+      subCommands: {
+        module: {
+          subCommands: {
+            add: { run: ({ args, rawArgs }) => runMock(args.cwd, rawArgs) },
+          },
+        },
+      },
     });
 
-    await runCommand(main, { rawArgs: ["--cwd", "playground", "module", "add", "nuxt-og-image"] });
+    await runCommand(command, {
+      rawArgs: ["--cwd", "playground", "module", "add", "nuxt-og-image"],
+    });
 
-    const { args, rawArgs } = run.mock.calls[0]![0];
-    expect(args.cwd).toBe("playground");
-    expect(rawArgs).toEqual(["--cwd", "playground", "nuxt-og-image"]);
+    expect(runMock).toHaveBeenCalledWith("playground", ["--cwd", "playground", "nuxt-og-image"]);
   });
 
-  it("should forward inherited args to a default sub command", async () => {
-    const run = vi.fn();
-    const dev = defineCommand({ run });
-    const main = defineCommand({
+  it("forwards inherited args to a default sub command", async () => {
+    const runMock = vi.fn();
+
+    const command = defineCommand({
       args: { cwd: { type: "string", inherit: true } },
-      subCommands: { dev },
+      subCommands: {
+        dev: { run: ({ args }) => runMock(args.cwd) },
+      },
       default: "dev",
     });
 
-    await runCommand(main, { rawArgs: ["--cwd", "playground"] });
+    await runCommand(command, { rawArgs: ["--cwd", "playground"] });
 
-    expect(run.mock.calls[0]![0].args.cwd).toBe("playground");
+    expect(runMock).toHaveBeenCalledWith("playground");
   });
 });


### PR DESCRIPTION
this adds support for inheriting args, so an arg can be passed to a parent or child equally (in my use case, `--cwd`)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for inheriting selected command-line arguments across subcommands.
  * Supports nested and default subcommands, aliases, boolean flags, enum values, and equal-value forms.
  * Added clear precedence handling when parent and subcommand arguments overlap.
  * Positional and passthrough arguments continue to work as expected.

* **Documentation**
  * Updated documentation for the `inherit` option and inherited argument behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->