### PR TITLE
feat: support positional enum args

### DIFF
--- a/src/args.ts
+++ b/src/args.ts
@@ -18,7 +18,7 @@ export function parseArgs<T extends ArgsDef = ArgsDef>(
   const args = resolveArgs(argsDef);
 
   for (const arg of args) {
-    if (arg.type === "positional") {
+    if (arg.type === "positional" || arg.positional) {
       continue;
     }
     if (arg.type === "string" || arg.type === "enum") {
@@ -60,7 +60,7 @@ export function parseArgs<T extends ArgsDef = ArgsDef>(
   });
 
   for (const [, arg] of args.entries()) {
-    if (arg.type === "positional") {
+    if (arg.type === "positional" || arg.positional) {
       const nextPositionalArgument = positionalArguments.shift();
       if (nextPositionalArgument !== undefined) {
         parsedArgsProxy[arg.name] = nextPositionalArgument;
@@ -72,16 +72,18 @@ export function parseArgs<T extends ArgsDef = ArgsDef>(
       } else {
         parsedArgsProxy[arg.name] = arg.default;
       }
-    } else if (arg.type === "enum") {
+    }
+
+    if (arg.type === "enum") {
       const argument = parsedArgsProxy[arg.name];
       const options = arg.options || [];
       if (argument !== undefined && options.length > 0 && !options.includes(argument)) {
         throw new CLIError(
-          `Invalid value for argument: ${cyan(`--${arg.name}`)} (${cyan(argument)}). Expected one of: ${options.map((o) => cyan(o)).join(", ")}.`,
+          `Invalid value for argument: ${arg.positional ? cyan(arg.name.toUpperCase()) : cyan(`--${arg.name}`)} (${cyan(argument)}). Expected one of: ${options.map((o) => cyan(o)).join(", ")}.`,
           "EARG",
         );
       }
-    } else if (arg.required && parsedArgsProxy[arg.name] === undefined) {
+    } else if (!(arg.type === "positional" || arg.positional) && arg.required && parsedArgsProxy[arg.name] === undefined) {
       throw new CLIError(`Missing required argument: --${arg.name}`, "EARG");
     }
   }

--- a/src/command.ts
+++ b/src/command.ts
@@ -189,7 +189,7 @@ function _isValueFlag(flag: string, argsDef: ArgsDef): boolean {
   for (const [key, def] of Object.entries(argsDef)) {
     if (def.type !== "string" && def.type !== "enum") continue;
     if (normalized === camelCase(key)) return true;
-    const aliases = Array.isArray(def.alias) ? def.alias : def.alias ? [def.alias] : [];
+    const aliases = "alias" in def && def.alias ? (Array.isArray(def.alias) ? def.alias : [def.alias]) : [];
     if (aliases.includes(name)) return true;
   }
   return false;

--- a/src/types.ts
+++ b/src/types.ts
@@ -8,11 +8,18 @@ export type _ArgDef<T extends ArgType, VT extends boolean | number | string> = {
   type?: T;
   description?: string;
   valueHint?: string;
-  alias?: string | string[];
   default?: VT;
   required?: boolean;
   options?: string[];
-};
+} & (
+  | {
+      alias?: string | string[];
+      positional?: false;
+    }
+  | {
+      positional: true;
+    }
+);
 
 export type BooleanArgDef = Omit<_ArgDef<"boolean", boolean>, "options"> & {
   negativeDescription?: string;

--- a/test/args.test.ts
+++ b/test/args.test.ts
@@ -50,6 +50,19 @@ describe("args", () => {
       { fooBar: { type: "enum", options: ["one", "two"], default: "two" } },
       { fooBar: "one", "foo-bar": "one", _: [] },
     ],
+    /**
+     * Positional String / Enum
+     */
+    [
+      ["my-string"],
+      { myArg: { type: "string", positional: true } },
+      { myArg: "my-string", _: ["my-string"] },
+    ],
+    [
+      ["one"],
+      { value: { type: "enum", positional: true, options: ["one", "two"] } },
+      { value: "one", _: ["one"] },
+    ],
   ] as [string[], ArgsDef, any][])(
     "should parsed correctly %o (%o)",
     (rawArgs, definition, result) => {
@@ -72,6 +85,11 @@ describe("args", () => {
       ["--value", "three"],
       { value: { type: "enum", options: ["one", "two"] } },
       "Invalid value for argument: --value (three). Expected one of: one, two.",
+    ],
+    [
+      ["three"],
+      { value: { type: "enum", positional: true, options: ["one", "two"] } },
+      "Invalid value for argument: VALUE (three). Expected one of: one, two.",
     ],
   ])("should throw error with %o (%o)", (rawArgs, definition, result) => {
     // TODO: should check for exact match


### PR DESCRIPTION
Fixes #251

This PR allows defining arguments (like strings and enums) as positional arguments using the `positional: true` flag, as suggested in #251. This enables taking advantage of things like enum validation for positional args without manually validating them.

When `positional: true` is provided, `alias` is omitted from the valid `ArgDef` options. Validation and fallback defaults are now executed correctly for these positional arguments.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Improved support for positional command-line arguments, including string and enum values.
  - Positional values are now parsed into named fields while remaining available by position.
  - Added clearer validation for invalid positional enum values.

- **Bug Fixes**
  - Corrected required-argument handling so positional arguments are validated appropriately.
  - Improved alias handling for argument definitions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->