### PR TITLE
fix: prevent bare string flag from consuming a following flag

### DIFF
--- a/src/_parser.ts
+++ b/src/_parser.ts
@@ -104,6 +104,27 @@ export function parseRawArgs<T = Record<string, any>>(
     }
   }
 
+  // Resolve a flag-like token to a known option name (long, short, or --no- form)
+  function knownOptionName(token: string): string | undefined {
+    if (!token.startsWith("-") || token === "-" || token === "--") {
+      return undefined;
+    }
+    let name: string;
+    if (token.startsWith("--")) {
+      name = token.slice(2);
+      const eqIndex = name.indexOf("=");
+      if (eqIndex !== -1) {
+        name = name.slice(0, eqIndex);
+      }
+      if (!allOptions.has(name) && name.startsWith("no-") && allOptions.has(name.slice(3))) {
+        name = name.slice(3);
+      }
+    } else {
+      name = token.slice(1, 2);
+    }
+    return allOptions.has(name) ? name : undefined;
+  }
+
   // Handle --no- prefixed arguments by preprocessing
   const processedArgs: string[] = [];
   const negatedFlags: Record<string, boolean> = {};
@@ -122,6 +143,23 @@ export function parseRawArgs<T = Record<string, any>>(
       const flagName = arg.slice(5);
       negatedFlags[flagName] = true;
       continue;
+    }
+
+    // A bare string option followed by another known flag should not consume
+    // that flag as its value; give it an explicit empty value instead.
+    if (arg.startsWith("-") && arg !== "-" && !arg.includes("=")) {
+      const name = knownOptionName(arg);
+      const next = args[i + 1];
+      if (
+        name !== undefined &&
+        isStringType(name) &&
+        next !== undefined &&
+        next !== "--" &&
+        knownOptionName(next) !== undefined
+      ) {
+        processedArgs.push(arg.startsWith("--") ? `${arg}=` : `--${name}=`);
+        continue;
+      }
     }
 
     processedArgs.push(arg);

--- a/src/_parser.ts
+++ b/src/_parser.ts
@@ -147,7 +147,12 @@ export function parseRawArgs<T = Record<string, any>>(
 
     // A bare string option followed by another known flag should not consume
     // that flag as its value; give it an explicit empty value instead.
-    if (arg.startsWith("-") && arg !== "-" && !arg.includes("=")) {
+    if (
+      arg.startsWith("-") &&
+      arg !== "-" &&
+      !arg.includes("=") &&
+      (arg.startsWith("--") || arg.length === 2)
+    ) {
       const name = knownOptionName(arg);
       const next = args[i + 1];
       if (

--- a/test/parser.test.ts
+++ b/test/parser.test.ts
@@ -113,6 +113,54 @@ describe("parseRawArgs", () => {
     });
   });
 
+  it("does not consume a following flag as the value of a bare string option", () => {
+    const result = parseRawArgs(["--host", "--cwd=playground"], {
+      string: ["host", "cwd"],
+    });
+
+    expect(result).toEqual({
+      _: [],
+      host: "",
+      cwd: "playground",
+    });
+  });
+
+  it("does not consume a following boolean flag as the value of a bare string option", () => {
+    const result = parseRawArgs(["--host", "--verbose"], {
+      string: ["host"],
+      boolean: ["verbose"],
+    });
+
+    expect(result).toEqual({
+      _: [],
+      host: "",
+      verbose: true,
+    });
+  });
+
+  it("does not consume a following short flag as the value of a bare string option", () => {
+    const result = parseRawArgs(["--host", "-v"], {
+      string: ["host"],
+      boolean: ["verbose"],
+      alias: { v: ["verbose"] },
+    });
+
+    expect(result._).toEqual([]);
+    expect(result.host).toBe("");
+    expect(result.verbose).toBe(true);
+  });
+
+  it("still consumes a hyphen-prefixed value that is not a known flag", () => {
+    const result = parseRawArgs(["--offset", "-1"], {
+      string: ["offset"],
+    });
+
+    expect(result).toEqual({
+      _: [],
+      offset: "-1",
+    });
+  });
+
   it("handles empty arguments", () => {
     const result = parseRawArgs([], {});
 

--- a/test/parser.test.ts
+++ b/test/parser.test.ts
@@ -150,6 +150,19 @@ describe("parseRawArgs", () => {
     expect(result.verbose).toBe(true);
   });
 
+  it("keeps the inline value of a short string option followed by a known flag", () => {
+    const result = parseRawArgs(["-xfoo", "--verbose"], {
+      string: ["x"],
+      boolean: ["verbose"],
+    });
+
+    expect(result).toEqual({
+      _: [],
+      x: "foo",
+      verbose: true,
+    });
+  });
+
   it("still consumes a hyphen-prefixed value that is not a known flag", () => {
     const result = parseRawArgs(["--offset", "-1"], {
       string: ["offset"],


### PR DESCRIPTION
the issue is something like `pnpm nuxt --host --cwd=playground` - `--host` should be set to `''` not `--cwd=playground`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed command-line parsing when a string option is followed by another recognized flag.
  * Bare string options now receive an empty value instead of incorrectly consuming the next flag.
  * Unknown hyphen-prefixed values continue to be handled as valid string input.

* **Tests**
  * Added coverage for long and short flag combinations and unknown hyphen-prefixed values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->