### PR TITLE
fix(command): do not run the parent after a sub command handled the run

### DIFF
--- a/src/command.ts
+++ b/src/command.ts
@@ -35,6 +35,7 @@ export async function runCommand<T extends ArgsDef = ArgsDef>(
   const plugins = await resolvePlugins(cmd.plugins ?? []);
 
   let result: unknown;
+  let subCommandRan = false;
   let runError: unknown;
   try {
     // Plugin setup hooks
@@ -58,9 +59,10 @@ export async function runCommand<T extends ArgsDef = ArgsDef>(
         if (!subCommand) {
           throw new CLIError(`Unknown command ${cyan(explicitName)}`, "E_UNKNOWN_COMMAND");
         }
-        await runCommand(subCommand, {
+        ({ result } = await runCommand(subCommand, {
           rawArgs: opts.rawArgs.slice(subCommandArgIndex + 1),
-        });
+        }));
+        subCommandRan = true;
       } else {
         // No explicit sub command — check for default
         const defaultSubCommand = await resolveValue(cmd.default);
@@ -78,17 +80,18 @@ export async function runCommand<T extends ArgsDef = ArgsDef>(
               "E_UNKNOWN_COMMAND",
             );
           }
-          await runCommand(subCommand, {
+          ({ result } = await runCommand(subCommand, {
             rawArgs: opts.rawArgs,
-          });
+          }));
+          subCommandRan = true;
         } else if (!cmd.run) {
           throw new CLIError(`No command specified.`, "E_NO_COMMAND");
         }
       }
     }
 
-    // Handle main command
-    if (typeof cmd.run === "function") {
+    // Handle main command — skipped when a sub command handled the invocation
+    if (!subCommandRan && typeof cmd.run === "function") {
       result = await cmd.run(context);
     }
   } catch (error) {

--- a/test/main.test.ts
+++ b/test/main.test.ts
@@ -141,6 +141,87 @@ describe("sub command", () => {
     expect(cleanupMock).toHaveBeenCalledOnce();
     expect(cleanupMock).toHaveBeenCalledWith("bar");
   });
+
+  it("does not run the parent when a sub command handles the invocation", async () => {
+    const parentRun = vi.fn();
+    const subRun = vi.fn();
+
+    const command = defineCommand({
+      run: parentRun,
+      subCommands: {
+        test: {
+          run: subRun,
+        },
+      },
+    });
+
+    await runMain(command, { rawArgs: ["test"] });
+
+    expect(subRun).toHaveBeenCalledOnce();
+    expect(parentRun).not.toHaveBeenCalled();
+  });
+
+  it("runs the parent when it has sub commands but none was named", async () => {
+    const parentRun = vi.fn();
+    const subRun = vi.fn();
+
+    const command = defineCommand({
+      run: parentRun,
+      subCommands: {
+        test: {
+          run: subRun,
+        },
+      },
+    });
+
+    await runMain(command, { rawArgs: [] });
+
+    expect(parentRun).toHaveBeenCalledOnce();
+    expect(subRun).not.toHaveBeenCalled();
+  });
+
+  it("returns the result of the sub command that ran", async () => {
+    const command = defineCommand({
+      run: () => "parent",
+      subCommands: {
+        test: {
+          run: () => "sub",
+        },
+      },
+    });
+
+    await expect(commandModule.runCommand(command, { rawArgs: ["test"] })).resolves.toEqual({
+      result: "sub",
+    });
+  });
+
+  it("does not run an intermediate parent of a nested sub command", async () => {
+    const order: string[] = [];
+
+    const command = defineCommand({
+      run: () => {
+        order.push("root");
+      },
+      subCommands: {
+        workspace: {
+          run: () => {
+            order.push("workspace");
+          },
+          subCommands: {
+            list: {
+              run: () => {
+                order.push("list");
+              },
+            },
+          },
+        },
+      },
+    });
+
+    await runMain(command, { rawArgs: ["workspace", "list"] });
+
+    expect(order).toEqual(["list"]);
+  });
 });
 
 describe("sub command aliases", () => {


### PR DESCRIPTION
Closes #253.

### The bug

A command that has both a `run` and `subCommands` runs twice — the sub command, then itself:

```js
const main = defineCommand({
  run: () => console.log("main"),
  subCommands: {
    test: { run: () => console.log("test") },
  },
});

runMain(main); // `cli test` prints: test, main
```

`runCommand` dispatches to the sub command and then falls straight through to the `if (typeof cmd.run === "function")` block below it, with nothing recording that the invocation was already handled. Nested commands are worse: `cli workspace list` runs `list`, then `workspace`, then the root, because each recursion level does the same thing on its way back up.

There is a second, quieter half to it. The dispatched call's return value is thrown away, so `runCommand(cmd, { rawArgs: ["test"] })` resolves to the *parent's* return value — or `{ result: undefined }` when the parent has no `run` at all, which is every ordinary CLI. The documented return of `runCommand` is unusable for anything but a bare top-level command.

### The fix

A `subCommandRan` flag guards the parent's `run`, and the dispatched result is assigned to `result` so it propagates back out.

The condition is deliberately "a sub command ran", not "this command has sub commands": a parent invoked with no sub command named still runs its own `run`, which is what makes a parent `run` useful as a fallback (`cli` with no args does something, `cli build` does something else). Both the explicit and the `default:` dispatch paths set it, since a defaulted sub command is just as much a handled invocation.

### Tests

Four in `test/main.test.ts`, all of which fail on `main`:

- the parent does not run when a sub command handles the invocation
- the parent *does* run when it has sub commands but none was named (guards against over-correcting)
- `runCommand` returns the sub command's result
- no intermediate ancestor runs for a nested sub command

`pnpm test` → 113 passed, 1 expected fail, no type errors; `pnpm lint` clean.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved command handling so a parent command no longer runs after a subcommand has been selected.
  * Ensured default and nested subcommands execute correctly without triggering intermediate parent commands.
  * Preserved and returned the result produced by the selected subcommand.
* **Tests**
  * Added coverage for subcommand execution, fallback behavior, result propagation, and nested command handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->