### PR TITLE
fix(types): preserve case alias argument types

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -1,3 +1,5 @@
+import type { CamelCase, KebabCase } from "scule";
+
 // ----- Args -----
 
 export type ArgType = "boolean" | "string" | "enum" | "positional" | undefined;
@@ -73,11 +75,16 @@ type ParsedArg<T extends ArgDef> =
   T["type"] extends "enum" ? ParsedEnumArg<T> :
   never;
 
+type ParsedCaseAlias<T extends ArgsDef> = {
+  [K in keyof T as K extends string ? CamelCase<K> | KebabCase<K> : never]: ParsedArg<T[K]>;
+};
+
 // prettier-ignore
 export type ParsedArgs<T extends ArgsDef = ArgsDef> = RawArgs &
   { [K in keyof T]: ParsedArg<T[K]>; } &
   { [K in keyof T as T[K] extends { alias: string } ? T[K]["alias"] : never]: ParsedArg<T[K]> } &
   { [K in keyof T as T[K] extends { alias: string[] } ? T[K]["alias"][number] : never]: ParsedArg<T[K]> } &
+  ParsedCaseAlias<T> &
   Record<string, string | number | boolean | string[]>;
 
 // ----- Command -----

--- a/test/types.test.ts
+++ b/test/types.test.ts
@@ -1,8 +1,8 @@
 import { describe, expect, it } from "vitest";
-import { defineCommand } from "../src/index.ts";
+import { defineCommand, runCommand } from "../src/index.ts";
 
 describe("ParsedArgs case aliases", () => {
-  it("preserves the argument type when accessed through camelCase", () => {
+  it("preserves the argument type when accessed through camelCase", async () => {
     const command = defineCommand({
       args: {
         "output-dir": { type: "string" },
@@ -11,10 +11,10 @@ describe("ParsedArgs case aliases", () => {
         const outputDir: string | undefined = args.outputDir;
         const kebabOutputDir: string | undefined = args["output-dir"];
 
-        expect([outputDir, kebabOutputDir]).toEqual([undefined, undefined]);
+        expect([outputDir, kebabOutputDir]).toEqual(["dist", "dist"]);
       },
     });
 
-    expect(command).toBeDefined();
+    await runCommand(command, { rawArgs: ["--output-dir", "dist"] });
   });
 });

--- a/test/types.test.ts
+++ b/test/types.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from "vitest";
+import { defineCommand } from "../src/index.ts";
+
+describe("ParsedArgs case aliases", () => {
+  it("preserves the argument type when accessed through camelCase", () => {
+    const command = defineCommand({
+      args: {
+        "output-dir": { type: "string" },
+      },
+      run({ args }) {
+        const outputDir: string | undefined = args.outputDir;
+        const kebabOutputDir: string | undefined = args["output-dir"];
+
+        expect([outputDir, kebabOutputDir]).toEqual([undefined, undefined]);
+      },
+    });
+
+    expect(command).toBeDefined();
+  });
+});


### PR DESCRIPTION
## Problem

For an argument defined with a kebab-case key such as `output-dir`, Citty supports accessing the parsed value through both `args["output-dir"]` and `args.outputDir` at runtime. The camelCase property currently falls back to the broad `ParsedArgs` index signature, so TypeScript users receive `string | number | boolean | string[] | undefined` instead of the argument’s declared type.

Fixes #244

## Fix

Add type-level `CamelCase` and `KebabCase` aliases to `ParsedArgs<T>` using the existing `scule` dependency. This keeps generated case aliases aligned with the runtime access behavior without changing parsing or emitted runtime code.

## Tests

- `pnpm test:types` — passed after the fix; the new regression assignment failed before the fix with TS2322.
- `pnpm exec vitest run test/types.test.ts` — passed; 1 test and no type errors.
- `pnpm test` — passed; 7 files, 110 passing tests, 1 intentional expected failure, no type errors.
- `pnpm build` — passed.
- `git diff HEAD^ HEAD --check` — passed.

## Compatibility

This is an additive type-level correction. Runtime parsing and existing explicit aliases are unchanged; the generated case aliases now expose their declared argument types.

## Related issue

Fixes #244


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Command arguments can be accessed using their original names, camelCase, or kebab-case aliases.
  * Type information is preserved across supported argument name formats.

* **Tests**
  * Added coverage confirming camelCase and kebab-case argument aliases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->