### PR TITLE
fix: forward selected subcommand result in runCommand (#273)

### DIFF
--- a/src/command.ts
+++ b/src/command.ts
@@ -58,9 +58,11 @@ export async function runCommand<T extends ArgsDef = ArgsDef>(
         if (!subCommand) {
           throw new CLIError(`Unknown command ${cyan(explicitName)}`, "E_UNKNOWN_COMMAND");
         }
-        await runCommand(subCommand, {
+        const sub = await runCommand(subCommand, {
           rawArgs: opts.rawArgs.slice(subCommandArgIndex + 1),
+          data: opts.data,
         });
+        result = sub.result;
       } else {
         // No explicit sub command — check for default
         const defaultSubCommand = await resolveValue(cmd.default);
@@ -78,9 +80,11 @@ export async function runCommand<T extends ArgsDef = ArgsDef>(
               "E_UNKNOWN_COMMAND",
             );
           }
-          await runCommand(subCommand, {
+          const sub = await runCommand(subCommand, {
             rawArgs: opts.rawArgs,
+            data: opts.data,
           });
+          result = sub.result;
         } else if (!cmd.run) {
           throw new CLIError(`No command specified.`, "E_NO_COMMAND");
         }

--- a/test/main.test.ts
+++ b/test/main.test.ts
@@ -1,5 +1,12 @@
 import { describe, it, expect, vi, afterAll } from "vitest";
-import { createMain, defineCommand, renderUsage, runMain, showUsage } from "../src/index.ts";
+import {
+  createMain,
+  defineCommand,
+  renderUsage,
+  runCommand,
+  runMain,
+  showUsage,
+} from "../src/index.ts";
 import * as commandModule from "../src/command.ts";
 
 describe("runMain", () => {
@@ -661,5 +668,38 @@ describe("createMain", () => {
     const main = createMain(defineCommand({}));
 
     expect(main).toBeInstanceOf(Function);
+  });
+});
+
+describe("runCommand result forwarding", () => {
+  it("forwards explicit subcommand result (#273)", async () => {
+    const main = defineCommand({
+      subCommands: {
+        child: defineCommand({
+          run() {
+            return { value: 42 };
+          },
+        }),
+      },
+    });
+
+    const { result } = await runCommand(main, { rawArgs: ["child"] });
+    expect(result).toEqual({ value: 42 });
+  });
+
+  it("forwards default subcommand result (#273)", async () => {
+    const main = defineCommand({
+      default: "child",
+      subCommands: {
+        child: defineCommand({
+          run() {
+            return "from-default";
+          },
+        }),
+      },
+    });
+
+    const { result } = await runCommand(main, { rawArgs: [] });
+    expect(result).toBe("from-default");
   });
 });


### PR DESCRIPTION
Resolves #273.

### Summary
When `runCommand()` executes an explicit or default subcommand, the recursive `await runCommand(subCommand, ...)` call was awaited without assigning its returned result. As a result, programmatic callers of `runCommand()` received `{ result: undefined }`.

This PR assigns `result = sub.result` so that the result of the invoked subcommand is properly returned from `runCommand()`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Command execution now returns the result produced by the selected subcommand, including default subcommands.
  * Shared command data is correctly passed through nested command execution.

* **Tests**
  * Added coverage confirming result forwarding for explicit and default subcommands.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->