### PR TITLE
fix(args): enforce `required` on enum arguments

### DIFF
--- a/src/args.ts
+++ b/src/args.ts
@@ -75,7 +75,13 @@ export function parseArgs<T extends ArgsDef = ArgsDef>(
     } else if (arg.type === "enum") {
       const argument = parsedArgsProxy[arg.name];
       const options = arg.options || [];
-      if (argument !== undefined && options.length > 0 && !options.includes(argument)) {
+      if (argument === undefined) {
+        // The enum branch is reached before the shared required check below,
+        // so it has to enforce `required` itself.
+        if (arg.required) {
+          throw new CLIError(`Missing required argument: --${arg.name}`, "EARG");
+        }
+      } else if (options.length > 0 && !options.includes(argument)) {
         throw new CLIError(
           `Invalid value for argument: ${cyan(`--${arg.name}`)} (${cyan(argument)}). Expected one of: ${options.map((o) => cyan(o)).join(", ")}.`,
           "EARG",

--- a/test/args.test.ts
+++ b/test/args.test.ts
@@ -50,6 +50,19 @@ describe("args", () => {
       { fooBar: { type: "enum", options: ["one", "two"], default: "two" } },
       { fooBar: "one", "foo-bar": "one", _: [] },
     ],
+    // A required enum is satisfied by its default
+    [
+      [],
+      {
+        value: {
+          type: "enum",
+          options: ["one", "two"],
+          default: "two",
+          required: true,
+        },
+      },
+      { value: "two", _: [] },
+    ],
   ] as [string[], ArgsDef, any][])(
     "should parsed correctly %o (%o)",
     (rawArgs, definition, result) => {
@@ -72,6 +85,11 @@ describe("args", () => {
       ["--value", "three"],
       { value: { type: "enum", options: ["one", "two"] } },
       "Invalid value for argument: --value (three). Expected one of: one, two.",
+    ],
+    [
+      [],
+      { value: { type: "enum", options: ["one", "two"], required: true } },
+      "Missing required argument: --value",
     ],
   ])("should throw error with %o (%o)", (rawArgs, definition, result) => {
     // TODO: should check for exact match


### PR DESCRIPTION
### Problem

`required: true` is silently ignored for `type: "enum"` arguments.

`parseArgs` validates each argument through one `if / else if` chain, and the generic required check is the last branch:

```ts
} else if (arg.type === "enum") {
  // ...only validates the value against `options`
} else if (arg.required && parsedArgsProxy[arg.name] === undefined) {
  throw new CLIError(`Missing required argument: --${arg.name}`, "EARG");
}
```

An enum argument always matches the `enum` branch, so it never reaches the required check. Omitting it yields `undefined` instead of an error:

```ts
parseArgs([], { value: { type: "enum", options: ["one", "two"], required: true } });
// -> { value: undefined, _: [] }   (expected: throws EARG)
```

The inconsistency is visible in the help output too: `usage.ts` reads `arg.required` for every non-positional type, so `--help` renders the argument as `(Required)` while the parser does not enforce it.

### Change

The enum branch now handles the missing-value case itself and throws the same `Missing required argument: --<name>` error the other types produce. The existing options check moves to the `else`, so a supplied value is validated exactly as before.

A default still satisfies the requirement — `parseRawArgs` has already applied `parseOptions.default` by this point, so `parsedArgsProxy[arg.name]` is defined. That matches how `required` + `default` behave for string arguments today.

### Scope

Anyone relying on the current behaviour was declaring `required: true` and getting nothing for it, so this only turns a silent `undefined` into the documented error.

### Tests

Two cases added to `test/args.test.ts`:

- a required enum with no value throws `Missing required argument: --value`;
- a required enum with a `default` parses to the default.

`pnpm test` passes: 111 tests + 1 expected fail, `oxlint`/`oxfmt` clean, `tsgo --noEmit` clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Required enum arguments without a provided value or default now correctly report a missing required argument error.
  - Required enum arguments with valid default values are accepted as expected.

- **Tests**
  - Added coverage for required enum arguments with and without default values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->